### PR TITLE
Fix/astroneer/security context

### DIFF
--- a/charts/astroneer/templates/configmaps.yaml
+++ b/charts/astroneer/templates/configmaps.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "astroneer.name" . }}-scripts
+  annotations:
+    {{- with .Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  labels:
+    {{- include "astroneer.labels" . | nindent 4 }}
+    app.kubernetes.io/name: {{ include "astroneer.name" . }}-scripts
+    app.kubernetes.io/component: {{ include "astroneer.name" . }}-scripts
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+data:
+  init-settings.sh:  |
+    #!/usr/bin/env bash
+    cd /settings
+    echo "[/Script/Astro.AstroServerSettings]" > AstroServerSettings.ini
+    vars=${!astroneer_*}
+    for i in $vars
+      do name=$(echo $i | sed -e "s/astroneer_//")
+      printf "%s=%s\n" "$name" "${!i}" >> AstroServerSettings.ini
+    done
+    echo "ConsolePassword=$CONSOLE_PASSWORD" >> AstroServerSettings.ini
+    echo "ServerPassword=$SERVER_PASSWORD" >> AstroServerSettings.ini

--- a/charts/astroneer/templates/deployments.yaml
+++ b/charts/astroneer/templates/deployments.yaml
@@ -23,10 +23,14 @@ spec:
         {{- toYaml . | nindent 4 }}
         {{- end }}
     spec:
+      securityContext:
+        {{- with .Values.podSecurityContext }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       containers:
         {{- if .Values.healthz.enabled }}
         - name: healthz
-          image: "chussenot/tiny-server:latest"
+          image: chussenot/tiny-server:latest
           imagePullPolicy: {{ .Values.image.imagePullPolicy }}
           ports:
             - name: healthz
@@ -61,6 +65,10 @@ spec:
             - name: {{ quote $k }}
               value: {{ quote $v }}
             {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             {{- if .Values.persistence.enabled }}
             - name: save-data
@@ -79,7 +87,7 @@ spec:
         - name: init-{{ include "astroneer.name" . }}-settings
           image: bash
           command:
-            - /bin/sh
+            - bash
             - -c
             - /scripts/init-settings.sh # creates the AstroServerSettings.ini from values.yaml
           env:
@@ -115,7 +123,7 @@ spec:
             - name: {{ include "astroneer.name" . }}-settings # ephemeral volume that stores AstroServerSettings.ini
               mountPath: /settings
             - name: scripts
-              mountPath:  /scripts
+              mountPath: /scripts
               readOnly: true
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- with .Values.image.imagePullSecrets }}
@@ -134,10 +142,10 @@ spec:
         - name: {{ include "astroneer.name" . }}-settings
           emptyDir: {}
         - name: scripts
-            configMap:
-              name: {{ include "astroneer.name" . }}-scripts
-              defaultMode: 0777
-              items:
+          configMap:
+            name: {{ include "astroneer.name" . }}-scripts
+            defaultMode: 0777
+            items:
               - key: init-settings.sh
                 path: init-settings.sh
         {{- range $index, $element := .Values.persistence.extra }}

--- a/charts/astroneer/templates/deployments.yaml
+++ b/charts/astroneer/templates/deployments.yaml
@@ -78,17 +78,10 @@ spec:
       initContainers:
         - name: init-{{ include "astroneer.name" . }}-settings
           image: bash
-          command: [ "bash", "-c", '
-              cd /settings;
-              echo "[/Script/Astro.AstroServerSettings]" > AstroServerSettings.ini;
-              vars=${!astroneer_*};
-              for i in $vars;
-                do name=$(echo $i | sed -e "s/astroneer_//");
-                printf "%s=%s\n" "$name" "${!i}" >> AstroServerSettings.ini;
-              done;
-              echo "ConsolePassword=$CONSOLE_PASSWORD" >> AstroServerSettings.ini;
-              echo "ServerPassword=$SERVER_PASSWORD" >> AstroServerSettings.ini;'
-          ] # creates the AstroServerSettings.ini from values.yaml
+          command:
+            - /bin/sh
+            - -c
+            - /scripts/init-settings.sh # creates the AstroServerSettings.ini from values.yaml
           env:
             {{- if .Values.secret.enable }}
             - name: SERVER_PASSWORD
@@ -121,6 +114,9 @@ spec:
           volumeMounts:
             - name: {{ include "astroneer.name" . }}-settings # ephemeral volume that stores AstroServerSettings.ini
               mountPath: /settings
+            - name: scripts
+              mountPath:  /scripts
+              readOnly: true
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- with .Values.image.imagePullSecrets }}
       imagePullSecrets:
@@ -137,6 +133,13 @@ spec:
             {{- end }}
         - name: {{ include "astroneer.name" . }}-settings
           emptyDir: {}
+        - name: scripts
+            configMap:
+              name: {{ include "astroneer.name" . }}-scripts
+              defaultMode: 0777
+              items:
+              - key: init-settings.sh
+                path: init-settings.sh
         {{- range $index, $element := .Values.persistence.extra }}
         {{- if $element.persistentVolumeClaim }}
         - name: {{ $element.name }}

--- a/charts/astroneer/templates/secrets.yaml
+++ b/charts/astroneer/templates/secrets.yaml
@@ -8,7 +8,6 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  namespace: {{ .Release.Namespace }}
   name: {{ include "astroneer.name" . }}-rcon-password
   annotations:
     {{- with .Values.annotations }}
@@ -30,7 +29,6 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  namespace: {{ .Release.Namespace }}
   name: {{ include "astroneer.name" . }}-password
   annotations:
     {{- with .Values.annotations }}

--- a/charts/astroneer/templates/volumes.yaml
+++ b/charts/astroneer/templates/volumes.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "astroneer.name" . }}-pvc
-  namespace: {{ .Release.Namespace }}
   annotations:
     {{- with .Values.annotations }}
     {{- toYaml . | nindent 4 }}
@@ -34,7 +33,6 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  namespace: {{ $.Release.Namespace }}
   name: "{{ $.Release.Name }}-{{ $element.name }}-pvc"
   annotations:
     {{- with $.Values.annotations }}

--- a/charts/astroneer/values.yaml
+++ b/charts/astroneer/values.yaml
@@ -8,6 +8,16 @@ image:
 
 # restartPolicy: unless-stopped
 
+podSecurityContext:
+  # fsGroup: 2000
+  # runAsNonRoot: true
+  # runAsUser: 1000
+  # runAsGroup: 1000
+  # seccompProfile:
+  #   type: RuntimeDefault
+
+securityContext: {}
+
 service:
   enabled: true
 
@@ -68,7 +78,7 @@ astroserversettings:
     astroneer_MaxServerIdleFramerate: 3.000000
     astroneer_bWaitForPlayersBeforeShutdown: false
     astroneer_PublicIP: ""
-    astroneer_ServerName: ""
+    astroneer_ServerName: "test"
     astroneer_ServerGuid: ""
     astroneer_OwnerName: ""
     astroneer_OwnerGuid: ""
@@ -91,7 +101,7 @@ launcher:
     DISABLE_ENCRYPTION: false # Disables connection encryption. default: false
     FORCE_CHOWN: false # chowns the astrotux folder on startup; potential workaround for an issue. default: false
 
-# TODO: Launcher has its own config, can set it up from values.yaml as well
+# TODO: Launcher has its own config for discord notifications and etc
 
 rcon:
   enable: true


### PR DESCRIPTION
* Added astroneer config map for init bash script so its easier to edit and is not in the container CMD section
* Added security context for user/file permissions and options to run as non-root. However current dockerfile requires root for launcher.toml