### PR TITLE
fix(radarr,prowlarr,sonarr): set deployment strategy to Recreate (0.1.2)

### DIFF
--- a/charts/prowlarr/Chart.yaml
+++ b/charts/prowlarr/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/prowlarr/templates/deployment.yaml
+++ b/charts/prowlarr/templates/deployment.yaml
@@ -8,6 +8,8 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "prowlarr.selectorLabels" . | nindent 6 }}

--- a/charts/radarr/Chart.yaml
+++ b/charts/radarr/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/radarr/templates/deployment.yaml
+++ b/charts/radarr/templates/deployment.yaml
@@ -8,6 +8,8 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "radarr.selectorLabels" . | nindent 6 }}

--- a/charts/sonarr/Chart.yaml
+++ b/charts/sonarr/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sonarr/templates/deployment.yaml
+++ b/charts/sonarr/templates/deployment.yaml
@@ -8,6 +8,8 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "sonarr.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
## Summary

- Adds `strategy: type: Recreate` to the Deployment spec in the radarr, prowlarr, and sonarr chart templates
- Bumps chart versions `0.1.1 → 0.1.2` for all three charts

## Why

RWO iSCSI volumes (backed by `freenas-iscsi-csi`) can only attach to one node at a time. With the default `RollingUpdate` strategy, Kubernetes creates the new pod before terminating the old one. If the scheduler places the new pod on a different node, it hangs indefinitely in `ContainerCreating` because the iSCSI volume is still attached to the original node — the old pod never terminates (it's still healthy), causing a permanent deadlock.

This was observed in production: prowlarr and radarr were stuck for 14 hours after a CI deploy bumped their image tags. Sonarr's iSCSI session also degraded after a rolling restart on the same node.

`Recreate` terminates the old pod first (releasing the volume), then starts the new one — a brief outage trades for a guaranteed clean attach every time.

## Test plan

- [ ] PR merged → `chart-releaser-action` publishes radarr/prowlarr/sonarr `0.1.2`
- [ ] GnorpLabs CI picks up new chart versions on next deploy
- [ ] Verify radarr, prowlarr, sonarr deployments show `strategy.type: Recreate` post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)