### PR TITLE
feat(mcp-gateway): add Helm chart

### DIFF
--- a/charts/mcp-gateway/Chart.yaml
+++ b/charts/mcp-gateway/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: mcp-gateway
+description: A Helm chart for MCP Gateway - Universal MCP Gateway with Meta-MCP
+type: application
+version: 0.1.0
+appVersion: "latest"

--- a/charts/mcp-gateway/templates/NOTES.txt
+++ b/charts/mcp-gateway/templates/NOTES.txt
@@ -1,0 +1,24 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "mcp-gateway.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "mcp-gateway.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "mcp-gateway.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:{{ .Values.service.port }}
+{{- end }}
+
+MCP Gateway dashboard: {{ if .Values.ingress.enabled }}https://{{ (index .Values.ingress.hosts 0).host }}{{ end }}/ui
+
+To verify the gateway is healthy:
+  kubectl exec -n {{ .Release.Namespace }} deploy/{{ include "mcp-gateway.fullname" . }} -- mcp-gateway doctor

--- a/charts/mcp-gateway/templates/_helpers.tpl
+++ b/charts/mcp-gateway/templates/_helpers.tpl
@@ -1,0 +1,60 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mcp-gateway.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "mcp-gateway.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mcp-gateway.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "mcp-gateway.labels" -}}
+helm.sh/chart: {{ include "mcp-gateway.chart" . }}
+{{ include "mcp-gateway.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "mcp-gateway.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mcp-gateway.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "mcp-gateway.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "mcp-gateway.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/mcp-gateway/templates/configmap.yaml
+++ b/charts/mcp-gateway/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mcp-gateway.fullname" . }}-config
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+data:
+  gateway.yaml: |
+    {{- toYaml .Values.gateway | nindent 4 }}

--- a/charts/mcp-gateway/templates/deployment.yaml
+++ b/charts/mcp-gateway/templates/deployment.yaml
@@ -1,0 +1,119 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mcp-gateway.fullname" . }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "mcp-gateway.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "mcp-gateway.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "mcp-gateway.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.stdioBackends.enabled }}
+      initContainers:
+        - name: setup-stdio-backends
+          image: {{ .Values.stdioBackends.nodeImage }}
+          command: ["sh", "-c"]
+          args:
+            - |
+              {{- range .Values.stdioBackends.packages }}
+              npm install -g {{ . }}
+              {{- end }}
+          volumeMounts:
+            - name: npx-bin
+              mountPath: /npx-bin
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args: ["--config", "/config.yaml"]
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          env:
+            {{- if .Values.stdioBackends.enabled }}
+            - name: PATH
+              value: "/usr/local/npx-bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+            {{- end }}
+            {{- range $key, $value := .Values.gateway.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- range .Values.gateway.envFromSecrets }}
+            - name: {{ .name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .secretName }}
+                  key: {{ .secretKey }}
+            {{- end }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /config.yaml
+              subPath: gateway.yaml
+              readOnly: true
+            {{- if .Values.stdioBackends.enabled }}
+            - name: npx-bin
+              mountPath: /usr/local/npx-bin
+            {{- end }}
+            {{- if .Values.persistence.enabled }}
+            - name: data
+              mountPath: /home/gateway/.mcp-gateway
+            {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "mcp-gateway.fullname" . }}-config
+        {{- if .Values.stdioBackends.enabled }}
+        - name: npx-bin
+          emptyDir: {}
+        {{- end }}
+        {{- if .Values.persistence.enabled }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "mcp-gateway.fullname" . }}-data
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/mcp-gateway/templates/ingress.yaml
+++ b/charts/mcp-gateway/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "mcp-gateway.fullname" . }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "mcp-gateway.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/mcp-gateway/templates/service.yaml
+++ b/charts/mcp-gateway/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mcp-gateway.fullname" . }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "mcp-gateway.selectorLabels" . | nindent 4 }}

--- a/charts/mcp-gateway/templates/serviceaccount.yaml
+++ b/charts/mcp-gateway/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mcp-gateway.serviceAccountName" . }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/mcp-gateway/templates/tests/connection-test.yaml
+++ b/charts/mcp-gateway/templates/tests/connection-test.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "mcp-gateway.fullname" . }}-test-connection"
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox:1.36
+      command: ['wget']
+      args: ['--spider', '--timeout=5', 'http://{{ include "mcp-gateway.fullname" . }}:{{ .Values.service.port }}/health']
+  restartPolicy: Never

--- a/charts/mcp-gateway/values.yaml
+++ b/charts/mcp-gateway/values.yaml
@@ -1,0 +1,139 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/mikkoparkkola/mcp-gateway
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  automount: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+securityContext: {}
+
+service:
+  type: ClusterIP
+  port: 39400
+
+ingress:
+  enabled: true
+  className: "traefik"
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    cert-manager.io/cluster-issuer: cloudflare-issuer
+  hosts:
+    - host: mcp-gateway.gnorplabs.cc
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: mcp-gateway-certificate
+      hosts:
+        - mcp-gateway.gnorplabs.cc
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+readinessProbe:
+  httpGet:
+    path: /health
+    port: http
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+persistence:
+  enabled: false
+  storageClass: "freenas-iscsi-csi"
+  accessMode: ReadWriteOnce
+  size: 1Gi
+
+stdioBackends:
+  enabled: false
+  nodeImage: "node:22-slim"
+  packages: []
+  # - "@modelcontextprotocol/server-filesystem@1.0.0"
+
+gateway:
+  server:
+    host: "0.0.0.0"
+    port: 39400
+    requestTimeout: 30s
+    shutdownTimeout: 30s
+  auth:
+    enabled: true
+    bearerToken: "auto"
+  metaMcp:
+    enabled: true
+    cacheTools: true
+    cacheTtl: 300s
+    warmStart: []
+  failsafe:
+    circuitBreaker:
+      enabled: true
+      failureThreshold: 5
+      successThreshold: 3
+      resetTimeout: 30s
+    retry:
+      enabled: true
+      maxAttempts: 3
+      initialBackoff: 0s
+      maxBackoff: 10s
+      multiplier: 2.0
+    rateLimit:
+      enabled: true
+      requestsPerSecond: 100
+      burstSize: 50
+    healthCheck:
+      enabled: true
+      interval: 30s
+      timeout: 5s
+  cache:
+    enabled: true
+    defaultTtl: 60s
+    maxEntries: 10000
+  capabilities:
+    enabled: false
+  security:
+    sanitizeInput: true
+    ssrfProtection: true
+    toolPolicy:
+      enabled: true
+      defaultAction: allow
+      useDefaultDeny: false
+      logDenied: true
+    firewall:
+      enabled: true
+      scanRequests: true
+      scanResponses: true
+      promptInjectionDetection: true
+      credentialRedaction: true
+  backends: {}
+  env: {}
+  envFromSecrets: []


### PR DESCRIPTION
## Summary

Adds a new `mcp-gateway` Helm chart to GnorpCharts for deploying [MCP Gateway](https://github.com/mikkoparkkola/mcp-gateway) — a universal MCP Gateway with Meta-MCP support.

## What's included

- `Chart.yaml` — chart metadata (v0.1.0)
- `values.yaml` — defaults covering server, auth, metaMcp, failsafe (circuit breaker / retry / rate limit / health check), cache, security (firewall / SSRF / tool policy), stdio backends (optional, disabled), ingress (traefik + cert-manager / cloudflare-issuer), resources
- `templates/` — deployment (with optional stdio init container), service, ingress, serviceaccount, configmap, NOTES.txt, connection test
- Traefik ingress with TLS via cert-manager `cloudflare-issuer`
- All security features enabled by default (firewall, SSRF protection, credential redaction, prompt injection detection)

## Validation

- `helm lint` — 0 failures
- `helm template` — renders SA, ConfigMap, Service, Deployment, Ingress (+ test Pod)
- `kubectl apply --dry-run=client` — all resources pass schema validation

## Merge order

This PR **must be merged first** (chart-releaser publishes the chart to the Helm index). Only then can the companion GnorpLabs PR be merged — its `helmfile apply` depends on `GnorpLabs/mcp-gateway` resolving.

## Known limitations

- stdio backends init container is disabled by default and as-written has a path mismatch between the init container's npm install target and the main container's PATH. Fix deferred until the feature is enabled.
- `bearerToken: "auto"` means the gateway self-generates a token at startup. Use a Sealed Secret via `gateway.envFromSecrets` if a stable token across restarts is needed.