### PR TITLE
feat: add data persistence key for single-mount hardlink support in radarr/sonarr charts

### DIFF
--- a/charts/radarr/Chart.yaml
+++ b/charts/radarr/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/radarr/templates/deployment.yaml
+++ b/charts/radarr/templates/deployment.yaml
@@ -56,35 +56,47 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
-            - name: media
-              mountPath: /tv
-              {{- if .Values.persistence.media.subPath }}
-              subPath: {{ .Values.persistence.media.subPath }}
-              {{- end }}
             - name: config
               mountPath: /config
               {{- if .Values.persistence.config.subPath }}
               subPath: {{ .Values.persistence.config.subPath }}
               {{- end }}
+            {{- if .Values.persistence.data.claimName }}
+            - name: data
+              mountPath: /data
+            {{- else }}
+            - name: media
+              mountPath: /data
+              {{- if .Values.persistence.media.subPath }}
+              subPath: {{ .Values.persistence.media.subPath }}
+              {{- end }}
             - name: downloads
-              mountPath: /downloads
+              mountPath: /data/usenet
               {{- if .Values.persistence.downloads.subPath }}
               subPath: {{ .Values.persistence.downloads.subPath }}
               {{- end }}
-      volumes:
-        - name: media
-          persistentVolumeClaim:
-            {{- if .Values.persistence.media.claimName }}
-            claimName: "{{ .Values.persistence.media.claimName }}"
-            {{- else }}
-            claimName: "{{ template "radarr.fullname" . }}-media"
             {{- end }}
+      volumes:
         - name: config
           persistentVolumeClaim:
             {{- if .Values.persistence.config.claimName }}
             claimName: "{{ .Values.persistence.config.claimName }}"
             {{- else }}
             claimName: "{{ template "radarr.fullname" . }}-config"
+            {{- end }}
+        {{- if .Values.persistence.data.claimName }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: "{{ .Values.persistence.data.claimName }}"
+            {{- if .Values.persistence.data.size }}
+            {{- end }}
+        {{- else }}
+        - name: media
+          persistentVolumeClaim:
+            {{- if .Values.persistence.media.claimName }}
+            claimName: "{{ .Values.persistence.media.claimName }}"
+            {{- else }}
+            claimName: "{{ template "radarr.fullname" . }}-media"
             {{- end }}
         - name: downloads
           persistentVolumeClaim:
@@ -93,6 +105,7 @@ spec:
               {{- else }}
               claimName: "{{ template "radarr.fullname" . }}-downloads"
               {{- end }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/radarr/templates/volumes.yaml
+++ b/charts/radarr/templates/volumes.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.persistence.data.claimName }}
+{{- else }}
 {{- if not .Values.persistence.config.claimName}}
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -63,4 +65,5 @@ spec:
   storageClassName: {{ .Values.persistence.media.storageClass | quote }}
 {{- end }}
 ---
+{{- end }}
 {{- end }}

--- a/charts/sonarr/Chart.yaml
+++ b/charts/sonarr/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sonarr/templates/deployment.yaml
+++ b/charts/sonarr/templates/deployment.yaml
@@ -56,35 +56,45 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
-            - name: media
-              mountPath: /tv
-              {{- if .Values.persistence.media.subPath }}
-              subPath: {{ .Values.persistence.media.subPath }}
-              {{- end }}
             - name: config
               mountPath: /config
               {{- if .Values.persistence.config.subPath }}
               subPath: {{ .Values.persistence.config.subPath }}
               {{- end }}
+            {{- if .Values.persistence.data.claimName }}
+            - name: data
+              mountPath: /data
+            {{- else }}
+            - name: media
+              mountPath: /data
+              {{- if .Values.persistence.media.subPath }}
+              subPath: {{ .Values.persistence.media.subPath }}
+              {{- end }}
             - name: downloads
-              mountPath: /downloads
+              mountPath: /data/usenet
               {{- if .Values.persistence.downloads.subPath }}
               subPath: {{ .Values.persistence.downloads.subPath }}
               {{- end }}
-      volumes:
-        - name: media
-          persistentVolumeClaim:
-            {{- if .Values.persistence.media.claimName }}
-            claimName: "{{ .Values.persistence.media.claimName }}"
-            {{- else }}
-            claimName: "{{ template "sonarr.fullname" . }}-media"
             {{- end }}
+      volumes:
         - name: config
           persistentVolumeClaim:
             {{- if .Values.persistence.config.claimName }}
             claimName: "{{ .Values.persistence.config.claimName }}"
             {{- else }}
             claimName: "{{ template "sonarr.fullname" . }}-config"
+            {{- end }}
+        {{- if .Values.persistence.data.claimName }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: "{{ .Values.persistence.data.claimName }}"
+        {{- else }}
+        - name: media
+          persistentVolumeClaim:
+            {{- if .Values.persistence.media.claimName }}
+            claimName: "{{ .Values.persistence.media.claimName }}"
+            {{- else }}
+            claimName: "{{ template "sonarr.fullname" . }}-media"
             {{- end }}
         - name: downloads
           persistentVolumeClaim:
@@ -93,6 +103,7 @@ spec:
               {{- else }}
               claimName: "{{ template "sonarr.fullname" . }}-downloads"
               {{- end }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/sonarr/templates/volumes.yaml
+++ b/charts/sonarr/templates/volumes.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.persistence.data.claimName }}
+{{- else }}
 {{- if not .Values.persistence.config.claimName}}
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -63,4 +65,5 @@ spec:
   storageClassName: {{ .Values.persistence.media.storageClass | quote }}
 {{- end }}
 ---
+{{- end }}
 {{- end }}


### PR DESCRIPTION
## Changes

Adds `persistence.data` key to radarr and sonarr chart templates to enable single-mount hardlink support for the download stack.

When `persistence.data.claimName` is set:
- Mounts the data PVC as a single volume at `/data`
- Downloads path moves to `/data/usenet`
- Skips creating separate media/downloads PVCs

When not set, falls back to the existing behavior (separate media and downloads mounts).

Bumps radarr and sonarr chart versions to 0.1.3.

## Why

Hardlinks require both source and destination to be on the same filesystem (same device number). Separate PVC mounts — even from the same underlying NFS export — get different device numbers inside the container, causing EXDEV errors on import. A single mount at `/data` means `/data/usenet/complete` and `/data/Movies` share the same device and hardlinks work.

## Companion changes

Values changes in GnorpLabs: `helm/helmfile/values/plex-stack/values-radarr.yaml`, `values-sonarr.yaml`, `values-sabnzbd.yaml`