### PR TITLE
fix(overseerr): bump chart version to 0.1.1 to trigger new release

### DIFF
--- a/charts/overseer/Chart.yaml
+++ b/charts/overseer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/recyclarr/Chart.yaml
+++ b/charts/recyclarr/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
 name: recyclarr
-description: A Helm chart for Kubernetes
+description: "[DEPRECATED] A Helm chart for Kubernetes - Use clonarr chart instead"
+deprecated: true
 
 # A chart can be either an 'application' or a 'library' chart.
 #


### PR DESCRIPTION
Bumps overseerr chart version from 0.1.0 to 0.1.1 to trigger a new chart release. The Zone.Identifier files were removed in commit 96bc355 but the chart version wasn't bumped, so the old version with those files is still being served from the Helm repo.