### PR TITLE
fix(seerr): remove duplicate security context keys and PUID/PGID env vars

### DIFF
--- a/charts/seerr/Chart.yaml
+++ b/charts/seerr/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 0.2.0
+version: 0.2.1
 
 appVersion: "v3.3.0"

--- a/charts/seerr/templates/deployment.yaml
+++ b/charts/seerr/templates/deployment.yaml
@@ -33,13 +33,6 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
-            runAsNonRoot: true
-            runAsUser: 1000
-            runAsGroup: 1000
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -48,10 +41,6 @@ spec:
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           env:
-            - name: PUID
-              value: "{{ .Values.env.PUID }}"
-            - name: PGID
-              value: "{{ .Values.env.PGID }}"
             - name: TZ
               value: "{{ .Values.env.TZ }}"
           livenessProbe:

--- a/charts/seerr/values.yaml
+++ b/charts/seerr/values.yaml
@@ -105,8 +105,6 @@ autoscaling:
 
 #container environment variables
 env:
-  PUID: "5000"
-  PGID: "1001"
   TZ: "America/New_York"
 
 #PVC for config, Plex Media, & Downloads


### PR DESCRIPTION
Fixes two issues with the seerr chart:

**1. Duplicate security context keys (YAML error)**
The deployment template had hardcoded securityContext keys AND `{{- toYaml .Values.securityContext | nindent 12 }}` which caused duplicate YAML keys, resulting in: `YAML parse error on seerr/templates/deployment.yaml: error converting YAML to JSON: yaml: line 38: did not find expected key`

Fix: removed the hardcoded keys — securityContext now comes entirely from `.Values.securityContext`.

**2. PUID/PGID env vars**
The chart had PUID/PGID env vars copied from the overseerr (LSIO) chart. The seerr image is not an LSIO image and doesn't use these vars. Removed.

Bumps chart to 0.2.1.