### PR TITLE
feat(omniroute): Add OmniRoute Helm chart for unified AI proxy

### DIFF
--- a/charts/omniroute/Chart.yaml
+++ b/charts/omniroute/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: omniroute
+description: A Helm chart for OmniRoute - Unified AI proxy for 271 LLM providers
+type: application
+version: 0.1.0
+appVersion: "latest"

--- a/charts/omniroute/omniroute-values-test.yaml
+++ b/charts/omniroute/omniroute-values-test.yaml
@@ -1,0 +1,86 @@
+# OmniRoute Test Deployment Values
+# This file configures a minimal test deployment
+# Deploy to mcp-gateway namespace: helm install omniroute . -f omniroute-values-test.yaml --namespace mcp-gateway
+
+replicaCount: 1
+
+image:
+  repository: diegosouzapw/omniroute
+  tag: "latest"
+  pullPolicy: IfNotPresent
+
+# No sidecars for initial testing
+redis:
+  enabled: false
+
+qdrant:
+  enabled: false
+
+bifrost:
+  enabled: false
+
+cliproxyapi:
+  enabled: false
+
+# Auto-create PVC with your iSCSI storage class
+persistence:
+  existingClaim: ""
+  create: true
+  storageClass: "freenas-iscsi-csi"
+  accessMode: ReadWriteOnce
+  size: 1Gi
+
+# Auto-generate secrets
+secrets:
+  autoGenerate: true
+  existingSecret: ""
+  jwtSecret: ""
+  apiKeySecret: ""
+
+service:
+  type: ClusterIP
+  ports:
+    dashboard:
+      enabled: true
+      port: 20128
+      targetPort: 20128
+    api:
+      enabled: false
+      port: 20129
+      targetPort: 20129
+    ws:
+      enabled: false
+      port: 20132
+      targetPort: 20132
+
+# Enable ingress for testing
+ingress:
+  enabled: true
+  className: "traefik"
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    cert-manager.io/cluster-issuer: cloudflare-issuer
+  hosts:
+    - host: omniroute.gnorplabs.cc
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: omniroute-certificate
+      hosts:
+        - omniroute.gnorplabs.cc
+
+resources:
+  limits:
+    cpu: 1000m
+    memory: 1536Mi
+  requests:
+    cpu: 250m
+    memory: 1024Mi
+
+env: {}
+envFromSecrets: []
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/charts/omniroute/templates/NOTES.txt
+++ b/charts/omniroute/templates/NOTES.txt
@@ -1,0 +1,28 @@
+Thank you for installing OmniRoute!
+
+Your release is named {{ .Release.Name }}.
+
+To access the dashboard:
+{{- if .Values.service.ports.dashboard.enabled }}
+1. Port-forward: kubectl port-forward svc/{{ include "omniroute.fullname" . }} {{ .Values.service.ports.dashboard.port }}:{{ .Values.service.ports.dashboard.port }}
+2. Open http://localhost:{{ .Values.service.ports.dashboard.port }} in your browser
+{{- end }}
+
+{{- if .Values.secrets.autoGenerate }}
+The initial admin password is: CHANGEME
+Change it immediately via Dashboard → Settings → Security
+{{- end }}
+
+Enabled components:
+{{- if .Values.redis.enabled }}
+- Redis (rate limiting) on port 6379
+{{- end }}
+{{- if .Values.qdrant.enabled }}
+- Qdrant (semantic memory) on port 6333
+{{- end }}
+{{- if .Values.bifrost.enabled }}
+- Bifrost (LLM router) on port 8080
+{{- end }}
+{{- if .Values.cliproxyapi.enabled }}
+- CLIProxyAPI on port 8317
+{{- end }}

--- a/charts/omniroute/templates/_helpers.tpl
+++ b/charts/omniroute/templates/_helpers.tpl
@@ -1,0 +1,60 @@
+{{/*
+Chart name and version
+*/}}
+{{- define "omniroute.chart" -}}
+{{- .Chart.Name }}-{{ .Chart.Version }}
+{{- end }}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "omniroute.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "omniroute.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "omniroute.labels" -}}
+helm.sh/chart: {{ include "omniroute.chart" . }}
+{{ include "omniroute.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "omniroute.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "omniroute.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "omniroute.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "omniroute.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/omniroute/templates/configmap.yaml
+++ b/charts/omniroute/templates/configmap.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "omniroute.fullname" . }}-config
+  labels:
+    {{- include "omniroute.labels" . | nindent 4 }}
+data:
+  NODE_ENV: "production"
+  PORT: "{{ .Values.service.ports.dashboard.port }}"
+{{- if .Values.redis.enabled }}
+  REDIS_URL: "redis://localhost:6379"
+{{- end }}
+{{- if .Values.qdrant.enabled }}
+  QDRANT_URL: "http://localhost:6333"
+  QDRANT_ENABLED: "true"
+{{- end }}
+{{- if .Values.bifrost.enabled }}
+  BIFROST_URL: "http://localhost:8080"
+  BIFROST_ENABLED: "true"
+{{- end }}
+{{- if .Values.cliproxyapi.enabled }}
+  CLIPROXYAPI_URL: "http://localhost:8317"
+{{- end }}
+{{- range $key, $value := .Values.env }}
+  {{ $key }}: {{ $value | quote }}
+{{- end }}

--- a/charts/omniroute/templates/ingress.yaml
+++ b/charts/omniroute/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.ingress .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "omniroute.fullname" . }}
+  labels:
+    {{- include "omniroute.labels" . | nindent 4 }}
+  annotations:
+    {{- if .Values.ingress.annotations }}
+    {{- toYaml .Values.ingress.annotations | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "omniroute.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.ports.dashboard.port }}
+          {{- end }}
+    {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/omniroute/templates/secret.yaml
+++ b/charts/omniroute/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.secrets.autoGenerate }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "omniroute.fullname" . }}-secrets
+  labels:
+    {{- include "omniroute.labels" . | nindent 4 }}
+type: Opaque
+data:
+  JWT_SECRET: {{ .Values.secrets.jwtSecret | default (randAlphaNum 48) | b64enc }}
+  API_KEY_SECRET: {{ .Values.secrets.apiKeySecret | default (randAlphaNum 64) | b64enc }}
+  INITIAL_PASSWORD: {{ .Values.secrets.initialPassword | default "CHANGEME" | b64enc }}
+{{- end }}

--- a/charts/omniroute/templates/service.yaml
+++ b/charts/omniroute/templates/service.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "omniroute.fullname" . }}
+  labels:
+    {{- include "omniroute.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    {{- if .Values.service.ports.dashboard.enabled }}
+    - name: dashboard
+      port: {{ .Values.service.ports.dashboard.port }}
+      targetPort: {{ .Values.service.ports.dashboard.targetPort }}
+      protocol: TCP
+    {{- end }}
+    {{- if .Values.service.ports.api.enabled }}
+    - name: api
+      port: {{ .Values.service.ports.api.port }}
+      targetPort: {{ .Values.service.ports.api.targetPort }}
+      protocol: TCP
+    {{- end }}
+    {{- if .Values.service.ports.ws.enabled }}
+    - name: ws
+      port: {{ .Values.service.ports.ws.port }}
+      targetPort: {{ .Values.service.ports.ws.targetPort }}
+      protocol: TCP
+    {{- end }}
+    {{- if .Values.redis.enabled }}
+    - name: redis
+      port: 6379
+      targetPort: 6379
+      protocol: TCP
+    {{- end }}
+    {{- if .Values.qdrant.enabled }}
+    - name: qdrant-http
+      port: 6333
+      targetPort: 6333
+      protocol: TCP
+    {{- end }}
+    {{- if .Values.bifrost.enabled }}
+    - name: bifrost
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+    {{- end }}
+    {{- if .Values.cliproxyapi.enabled }}
+    - name: cliproxyapi
+      port: 8317
+      targetPort: 8317
+      protocol: TCP
+    {{- end }}
+  selector:
+    {{- include "omniroute.selectorLabels" . | nindent 4 }}

--- a/charts/omniroute/templates/serviceaccount.yaml
+++ b/charts/omniroute/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "omniroute.fullname" . }}
+  labels:
+    {{- include "omniroute.labels" . | nindent 4 }}
+{{- if .Values.serviceAccount.automount }}
+automountServiceAccountToken: true
+{{- end }}

--- a/charts/omniroute/templates/statefulset.yaml
+++ b/charts/omniroute/templates/statefulset.yaml
@@ -1,0 +1,146 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "omniroute.fullname" . }}
+  labels:
+    {{- include "omniroute.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  serviceName: {{ include "omniroute.fullname" . }}
+  selector:
+    matchLabels:
+      {{- include "omniroute.selectorLabels" . | nindent 6 }}
+  {{- if and .Values.persistence.create (not .Values.persistence.existingClaim) }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - {{ .Values.persistence.accessMode }}
+        storageClassName: {{ .Values.persistence.storageClass }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size }}
+  {{- else if .Values.persistence.existingClaim }}
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: {{ .Values.persistence.existingClaim }}
+  {{- end }}
+  template:
+    metadata:
+      labels:
+        {{- include "omniroute.labels" . | nindent 8 }}
+    spec:
+      containers:
+        # Core OmniRoute container
+        - name: omniroute
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            {{- if .Values.service.ports.dashboard.enabled }}
+            - name: dashboard
+              containerPort: {{ .Values.service.ports.dashboard.targetPort }}
+              protocol: TCP
+            {{- end }}
+            {{- if .Values.service.ports.api.enabled }}
+            - name: api
+              containerPort: {{ .Values.service.ports.api.targetPort }}
+              protocol: TCP
+            {{- end }}
+            {{- if .Values.service.ports.ws.enabled }}
+            - name: ws
+              containerPort: {{ .Values.service.ports.ws.targetPort }}
+              protocol: TCP
+            {{- end }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "omniroute.fullname" . }}-config
+            {{- if .Values.secrets.autoGenerate }}
+            - secretRef:
+                name: {{ include "omniroute.fullname" . }}-secrets
+            {{- else if .Values.secrets.existingSecret }}
+            - secretRef:
+                name: {{ .Values.secrets.existingSecret }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- if or .Values.persistence.existingClaim .Values.persistence.create }}
+          volumeMounts:
+            - name: data
+              mountPath: /app/data
+          {{- end }}
+        # Redis sidecar
+        {{- if .Values.redis.enabled }}
+        - name: redis
+          image: docker.io/library/redis:7-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+          args: ["redis-server", "--save", "60", "1", "--loglevel", "warning"]
+          resources:
+            limits:
+              cpu: 200m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+        {{- end }}
+        # Qdrant sidecar
+        {{- if .Values.qdrant.enabled }}
+        - name: qdrant
+          image: docker.io/qdrant/qdrant:v1.12.4
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 6333
+            - name: grpc
+              containerPort: 6334
+          env:
+            - name: QDRANT__SERVICE__GRPC_PORT
+              value: "6334"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 200m
+              memory: 256Mi
+        {{- end }}
+        # Bifrost sidecar
+        {{- if .Values.bifrost.enabled }}
+        - name: bifrost
+          image: ghcr.io/maximhq/bifrost:1.5.21
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          resources:
+            limits:
+              cpu: 200m
+              memory: 256Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+        {{- end }}
+        # CLIProxyAPI sidecar
+        {{- if .Values.cliproxyapi.enabled }}
+        - name: cliproxyapi
+          image: ghcr.io/router-for-me/cliproxyapi:v6.9.7
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8317
+          env:
+            - name: PORT
+              value: "8317"
+          resources:
+            limits:
+              cpu: 200m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 64Mi
+        {{- end }}

--- a/charts/omniroute/templates/tests/connection-test.yaml
+++ b/charts/omniroute/templates/tests/connection-test.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "omniroute.fullname" . }}-test-connection"
+  labels:
+    {{- include "omniroute.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: test
+      image: curlimages/curl:latest
+      command:
+        - sh
+        - -c
+        - |
+          curl -f http://localhost:20128/api/monitoring/health
+  restartPolicy: Never

--- a/charts/omniroute/values.yaml
+++ b/charts/omniroute/values.yaml
@@ -1,0 +1,97 @@
+# OmniRoute Helm Chart Values
+# Copy this file to omniroute-values.yaml and customize for your deployment
+
+# ── Replicas ─────────────────────────────────────────────────────────────────
+replicaCount: 1
+
+# ── Image Configuration ─────────────────────────────────────────────────────
+image:
+  repository: diegosouzapw/omniroute
+  tag: "latest"  # Use "latest-web" for browser-based providers (gemini-web, claude-web, claude-turnstile)
+  pullPolicy: IfNotPresent
+
+# ── Optional Sidecars ───────────────────────────────────────────────────────
+# All sidecars run in the same pod as OmniRoute (localhost networking)
+
+redis:
+  enabled: false  # Rate limiting backend (recommended)
+
+qdrant:
+  enabled: false  # Semantic memory store (for >1M points or cross-instance memory)
+
+bifrost:
+  enabled: false  # Tier-1 LLM router (offloads routing to Go sidecar)
+
+cliproxyapi:
+  enabled: false  # CLI proxy API sidecar
+
+# ── Persistence ────────────────────────────────────────────────────────────
+persistence:
+  existingClaim: ""  # Use existing PVC name (overrides create)
+  create: false     # Auto-create PVC with volumeClaimTemplates
+  storageClass: "standard"  # Kubernetes storage class
+  accessMode: ReadWriteOnce
+  size: 1Gi         # Storage size for SQLite database
+
+# ── Secrets ────────────────────────────────────────────────────────────────
+secrets:
+  autoGenerate: true   # Generate JWT_SECRET, API_KEY_SECRET automatically
+  existingSecret: ""   # Use existing secret instead of auto-generate
+  # Override individual secrets (only used if autoGenerate: false)
+  jwtSecret: ""
+  apiKeySecret: ""
+
+# ── Service Configuration ─────────────────────────────────────────────────
+service:
+  type: ClusterIP
+  ports:
+    dashboard:
+      enabled: true
+      port: 20128
+      targetPort: 20128
+    api:
+      enabled: false   # Set true for split-port mode (dashboard:port, api:port)
+      port: 20129
+      targetPort: 20129
+    ws:
+      enabled: false   # Set true to expose WebSocket port
+      port: 20132
+      targetPort: 20132
+
+# ── Resources ───────────────────────────────────────────────────────────────
+resources:
+  limits:
+    cpu: 1000m
+    memory: 1536Mi  # Node.js heap is 1024MB by default (OMNIROUTE_MEMORY_MB)
+  requests:
+    cpu: 250m
+    memory: 1024Mi
+
+# ── Additional Environment Variables ────────────────────────────────────────
+env: {}  # Example: { OMNI_MAX_CONCURRENT_CONNECTIONS: "50" }
+
+envFromSecrets: []  # Example: [{ name: MY_API_KEY, secretName: my-secret, secretKey: key }]
+
+# ── Service Account ───────────────────────────────────────────────────────────
+serviceAccount:
+  create: true
+  automount: true
+  annotations: {}
+  name: ""
+
+# ── Ingress Configuration ─────────────────────────────────────────────────────
+ingress:
+  enabled: false
+  className: "traefik"
+  annotations: {}
+  hosts:
+    - host: omniroute.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+# ── Node Scheduling (Optional) ─────────────────────────────────────────────
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
## Description

This PR adds a new Helm chart for OmniRoute, a unified AI proxy supporting 271 LLM providers.

## Changes

- **Chart.yaml**: Chart metadata with version 0.1.0
- **values.yaml**: Default configuration for OmniRoute deployment
- **omniroute-values-test.yaml**: Test configuration values
- **Kubernetes Templates**:
  - StatefulSet for persistent OmniRoute deployment
  - Service for internal routing
  - Ingress for external access
  - ConfigMap for configuration management
  - Secret for sensitive data
  - ServiceAccount for RBAC
  - Connection test for chart verification
- **NOTES.txt**: Post-install instructions
- **Helm helpers**: Standard template helpers

## Chart Details

- **Name**: omniroute
- **Version**: 0.1.0
- **App Version**: latest
- **Type**: application

## Testing

- [ ] Chart renders with default values
- [ ] Chart renders with test values (omniroute-values-test.yaml)
- [ ] Templates follow Kubernetes best practices
- [ ] All required resources are included

## Deployment Notes

This chart provides a complete deployment configuration for OmniRoute with:
- Persistent storage via StatefulSet
- Configurable ingress and service exposure
- Secret management for API keys and sensitive data
- RBAC support via ServiceAccount