### PR TITLE
feat(agentmemory): Add AgentMemory Helm chart with MCP integration

### DIFF
--- a/charts/agentmemory/.helmignore
+++ b/charts/agentmemory/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/agentmemory/AGENTMEMORY_AUTH_INTEGRATION.md
+++ b/charts/agentmemory/AGENTMEMORY_AUTH_INTEGRATION.md
@@ -1,0 +1,287 @@
+# AgentMemory Authentication Integration Plan
+
+## Overview
+
+AgentMemory now supports auto-generated authentication secrets. This document outlines how to integrate the authenticated AgentMemory with mcp-gateway.
+
+## Changes Made to AgentMemory Chart
+
+### 1. Auto-Generated Secret
+- **Location:** `templates/secret.yaml`
+- **Behavior:** Generates a random 32-character secret on first install
+- **Annotation:** `helm.sh/resource-policy: keep` - prevents deletion on upgrade
+- **Secret Name:** `<release-name>-auth`
+- **Secret Key:** `agentmemory-secret`
+
+### 2. Values Configuration
+```yaml
+auth:
+  enabled: true              # Enable authentication (default: true)
+  autoGenerate: true         # Auto-generate secret (default: true)
+  existingSecret: ""         # Use existing secret (optional)
+  secret: ""                 # Manually specify secret (if autoGenerate=false)
+
+env:
+  AGENTMEMORY_VIEWER_HOST: "0.0.0.0"  # Bind viewer to all interfaces when auth enabled
+```
+
+### 3. Deployment Changes
+- Injects `AGENTMEMORY_SECRET` from Kubernetes Secret when `auth.enabled=true`
+- Sets `AGENTMEMORY_VIEWER_HOST=0.0.0.0` when auth is enabled
+- Disables `viewerProxy` socat sidecar when auth is enabled
+- Uses standard HTTP ingress instead of TCP ingress when auth is enabled
+
+## Integration Options for mcp-gateway
+
+### Option 1: Token Replacement Pattern (Recommended)
+**Approach:** Store the secret in GitHub Actions secrets and use `__TOKEN__` placeholders that get replaced by `qetza/replacetokens-action` during deployment. This matches the existing pattern used for `__OMNIROUTE_MCP_API_KEY__`.
+
+**Pros:**
+- Single source of truth (GitHub Secrets)
+- No coupling between charts
+- GitOps-friendly
+- Easy secret rotation
+- No RBAC complexity
+- Works with any CI/CD system
+
+**Cons:**
+- Secret visible in Helm values (but not committed to git)
+- Requires CI/CD pipeline
+
+**Implementation:**
+
+#### Step 1: Initial Deploy (auto-generate secret)
+```yaml
+# GnorpLabs/helm/helmfile/values/infra/values-agentmemory.yaml
+auth:
+  enabled: true
+  autoGenerate: true  # AgentMemory generates the secret
+```
+
+Deploy, then extract:
+```bash
+kubectl get secret agentmemory-auth -n mcp-gateway \
+  -o jsonpath='{.data.agentmemory-secret}' | base64 -d
+```
+
+#### Step 2: Add to GitHub Secrets
+- Settings → Secrets → Actions → `AGENTMEMORY_SECRET`
+- Paste the auto-generated value from Step 1
+
+#### Step 3: Update values-agentmemory.yaml to use token replacement
+```yaml
+# GnorpLabs/helm/helmfile/values/infra/values-agentmemory.yaml
+auth:
+  enabled: true
+  autoGenerate: false
+  secret: "__AGENTMEMORY_SECRET__"
+```
+
+#### Step 3: Update values-mcp-gateway.yaml
+```yaml
+# GnorpLabs/helm/helmfile/values/infra/values-mcp-gateway.yaml
+gateway:
+  backends:
+    agentmemory:
+      http_url: "http://agentmemory.mcp-gateway.svc.cluster.local:3114/mcp"
+      description: "Persistent memory for AI agents"
+      streamable_http: true
+      headers:
+        Authorization: "Bearer __AGENTMEMORY_SECRET__"
+```
+
+#### Step 4: Existing Workflow Handles Token Replacement
+Your existing `qetza/replacetokens-action` step already handles this:
+```yaml
+# .github/workflows/deploy.yml (existing)
+- name: Replace tokens
+  uses: qetza/replacetokens-action@v3
+  with:
+    files: 'helm/helmfile/values/**/*.yaml'
+    tokenPrefix: '__'
+    tokenSuffix: '__'
+```
+
+The `__AGENTMEMORY_SECRET__` tokens are automatically replaced with the GitHub Secret value.
+
+**See `DEPLOYMENT.md` for complete guide.**
+
+### Option 2: Kubernetes Secret Reference (Alternative)
+**Approach:** mcp-gateway reads the Kubernetes Secret created by AgentMemory.
+
+**Pros:**
+- Kubernetes-native
+- No external dependencies
+
+**Cons:**
+- Tight coupling between charts
+- Requires RBAC permissions for cross-secret access
+- More complex than GitHub Actions approach
+
+**Implementation:** See previous version of this doc or use Option 1 instead.
+
+### Option 3: ServiceAccount Token Projection (Future)
+**Approach:** Use Kubernetes ServiceAccount tokens for authentication.
+
+**Status:** Not currently supported by AgentMemory v0.11.2 (requires upstream changes)
+
+### Option 4: Separate Secrets (Not Recommended)
+**Approach:** Create two separate secrets with the same value.
+
+**Cons:**
+- Manual sync required
+- Easy to drift
+- Violates DRY principle
+
+## Recommended Implementation Steps
+
+### 1. Deploy AgentMemory with auth enabled
+```bash
+helm upgrade --install agentmemory ./charts/agentmemory \
+  -n mcp-gateway \
+  --set auth.enabled=true \
+  --set auth.autoGenerate=true
+```
+
+### 2. Retrieve the generated secret
+```bash
+kubectl get secret agentmemory-auth -n mcp-gateway -o jsonpath='{.data.agentmemory-secret}' | base64 -d
+```
+
+### 3. Update mcp-gateway values
+```yaml
+# values/mcp-gateway.yaml
+agentmemory:
+  secretRef:
+    name: "agentmemory-auth"
+    key: "agentmemory-secret"
+  url: "http://agentmemory.mcp-gateway.svc.cluster.local:3111"
+```
+
+### 4. Update mcp-gateway deployment template
+Add the environment variables to read the secret (see Option 1 above).
+
+### 5. Configure mcp-gateway backend
+Update the AgentMemory backend in mcp-gateway's config to include auth headers.
+
+### 6. Deploy mcp-gateway
+```bash
+helm upgrade --install mcp-gateway ./charts/mcp-gateway \
+  -n mcp-gateway \
+  -f values/mcp-gateway.yaml
+```
+
+## Verification
+
+### 1. Check AgentMemory secret exists
+```bash
+kubectl get secret agentmemory-auth -n mcp-gateway
+```
+
+### 2. Test authenticated access
+```bash
+# Get the secret value
+SECRET=$(kubectl get secret agentmemory-auth -n mcp-gateway -o jsonpath='{.data.agentmemory-secret}' | base64 -d)
+
+# Test API with auth
+kubectl run -it --rm curl --image=curlimages/curl -n mcp-gateway -- \
+  curl -H "Authorization: Bearer $SECRET" \
+  http://agentmemory.mcp-gateway.svc.cluster.local:3111/agentmemory/health
+```
+
+### 3. Check mcp-gateway can access AgentMemory
+```bash
+kubectl logs -n mcp-gateway deployment/mcp-gateway | grep -i agentmemory
+```
+
+## Migration from No-Auth Setup
+
+If you're migrating from the previous no-auth setup:
+
+1. **Before migration:** Document current mcp-gateway configuration
+2. **Enable auth on AgentMemory:**
+   ```bash
+   helm upgrade agentmemory ./charts/agentmemory \
+     -n mcp-gateway \
+     --set auth.enabled=true \
+     --reuse-values
+   ```
+3. **Update mcp-gateway** to use the secret (see steps above)
+4. **Verify functionality** before removing old TCP ingress configuration
+5. **Clean up:** Remove TCP ingress resources if no longer needed
+
+## Security Considerations
+
+1. **Secret Rotation:** To rotate the secret:
+   ```bash
+   # Delete the secret (will be regenerated on next upgrade)
+   kubectl delete secret agentmemory-auth -n mcp-gateway
+   
+   # Upgrade to regenerate
+   helm upgrade agentmemory ./charts/agentmemory -n mcp-gateway
+   
+   # Restart mcp-gateway to pick up new secret
+   kubectl rollout restart deployment/mcp-gateway -n mcp-gateway
+   ```
+
+2. **RBAC:** Ensure mcp-gateway ServiceAccount has permission to read the secret:
+   ```yaml
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: Role
+   metadata:
+     name: mcp-gateway-secret-reader
+     namespace: mcp-gateway
+   rules:
+   - apiGroups: [""]
+     resources: ["secrets"]
+     resourceNames: ["agentmemory-auth"]
+     verbs: ["get"]
+   ```
+
+3. **Network Policies:** With auth enabled, consider restricting network access:
+   ```yaml
+   apiVersion: networking.k8s.io/v1
+   kind: NetworkPolicy
+   metadata:
+     name: agentmemory-api-access
+     namespace: mcp-gateway
+   spec:
+     podSelector:
+       matchLabels:
+         app.kubernetes.io/name: agentmemory
+     policyTypes:
+     - Ingress
+     ingress:
+     - from:
+       - podSelector:
+           matchLabels:
+             app.kubernetes.io/name: mcp-gateway
+       ports:
+       - protocol: TCP
+         port: 3111
+   ```
+
+## Troubleshooting
+
+### mcp-gateway can't authenticate
+- Verify secret exists: `kubectl get secret agentmemory-auth -n mcp-gateway`
+- Check secret is mounted: `kubectl describe pod <mcp-gateway-pod> -n mcp-gateway`
+- Verify secret value: `kubectl get secret agentmemory-auth -n mcp-gateway -o jsonpath='{.data.agentmemory-secret}' | base64 -d`
+
+### Viewer not accessible
+- Check ingress is HTTP (not TCP): `kubectl get ingress -n mcp-gateway`
+- Verify `AGENTMEMORY_VIEWER_HOST=0.0.0.0` is set in pod env
+- Check auth is enabled: `helm get values agentmemory -n mcp-gateway`
+
+### Secret regenerates on every upgrade
+- Ensure `helm.sh/resource-policy: keep` annotation is present
+- Use `--reuse-values` flag during upgrades
+- Consider using `existingSecret` for production
+
+## Next Steps
+
+1. Implement Option 1 (recommended) in mcp-gateway chart
+2. Test in staging environment
+3. Document upgrade path for production
+4. Consider implementing NetworkPolicies for additional security
+5. Plan for secret rotation strategy

--- a/charts/agentmemory/Chart.yaml
+++ b/charts/agentmemory/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: agentmemory
+description: Persistent memory server for AI coding agents (iii engine + MCP)
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "latest"

--- a/charts/agentmemory/DEPLOYMENT.md
+++ b/charts/agentmemory/DEPLOYMENT.md
@@ -1,0 +1,159 @@
+# AgentMemory Deployment Guide
+
+## Secret Management
+
+AgentMemory supports authentication with an auto-generated secret. The secret can be shared with mcp-gateway using **two patterns** - choose the one that fits your workflow.
+
+## Two Deployment Patterns
+
+### Option A: Kubernetes Secret (Recommended for Cluster)
+
+**Fully automated - zero manual steps.**
+
+AgentMemory auto-generates a secret, stores it in K8s Secret `agentmemory-auth`, and mcp-gateway reads it via `envFromSecrets`.
+
+#### AgentMemory values
+```yaml
+# GnorpLabs/helm/helmfile/values/infra/values-agentmemory.yaml
+auth:
+  enabled: true
+  autoGenerate: true  # Auto-generates on first install
+```
+
+#### mcp-gateway values
+```yaml
+# GnorpLabs/helm/helmfile/values/infra/values-mcp-gateway.yaml
+gateway:
+  envFromSecrets:
+    - name: AGENTMEMORY_SECRET
+      secretName: agentmemory-auth
+      secretKey: agentmemory-secret
+  backends:
+    agentmemory:
+      http_url: "http://agentmemory.mcp-gateway.svc.cluster.local:3114/mcp"
+      streamable_http: true
+      headers:
+        Authorization: "Bearer ${AGENTMEMORY_SECRET}"
+```
+
+**Deploy and done.** No extraction, no GitHub Secrets, no token replacement needed.
+
+---
+
+### Option B: Token Replacement (GitOps Pattern)
+
+**Best for secret rotation via GitHub Actions.**
+
+#### Step 1: Deploy AgentMemory (auto-generates secret)
+```yaml
+# values-agentmemory.yaml
+auth:
+  enabled: true
+  autoGenerate: true
+```
+
+#### Step 2: Extract the generated secret
+```bash
+kubectl get secret agentmemory-auth -n mcp-gateway \
+  -o jsonpath='{.data.agentmemory-secret}' | base64 -d
+```
+
+#### Step 3: Add to GitHub Secrets
+- Settings → Secrets → Actions → `AGENTMEMORY_SECRET`
+
+#### Step 4: Update values to use token replacement
+```yaml
+# values-agentmemory.yaml
+auth:
+  enabled: true
+  autoGenerate: false
+  secret: "__AGENTMEMORY_SECRET__"
+
+# values-mcp-gateway.yaml
+gateway:
+  backends:
+    agentmemory:
+      headers:
+        Authorization: "Bearer __AGENTMEMORY_SECRET__"
+```
+
+Your existing `qetza/replacetokens-action` handles the replacement.
+
+#### mcp-gateway (`values-mcp-gateway.yaml`)
+```yaml
+gateway:
+  backends:
+    agentmemory:
+      http_url: "http://agentmemory.mcp-gateway.svc.cluster.local:3114/mcp"
+      description: "Persistent memory for AI agents"
+      streamable_http: true
+      headers:
+        Authorization: "Bearer __AGENTMEMORY_SECRET__"
+```
+
+### Existing Deployment Workflow
+
+Your existing workflow already handles token replacement:
+
+```yaml
+# .github/workflows/deploy.yml (your existing workflow)
+- name: Replace tokens
+  uses: qetza/replacetokens-action@v3
+  with:
+    files: |
+      helm/helmfile/values/**/*.yaml
+    tokenPrefix: '__'
+    tokenSuffix: '__'
+
+# Then your normal helm/helmfile deployment
+- name: Deploy
+  run: helmfile apply
+```
+
+The `__AGENTMEMORY_SECRET__` tokens in both values files will be replaced with the actual secret from GitHub Secrets.
+
+## Local Development
+
+For local testing without token replacement:
+
+```bash
+# Set environment variable
+export AGENTMEMORY_SECRET="local-dev-secret-change-me"
+
+# Deploy agentmemory
+helm upgrade --install agentmemory ./charts/agentmemory \
+  -n mcp-gateway --create-namespace \
+  --set auth.enabled=true \
+  --set auth.autoGenerate=false \
+  --set-string auth.secret="$AGENTMEMORY_SECRET"
+
+# Update mcp-gateway values manually or use sed
+sed "s/__AGENTMEMORY_SECRET__/$AGENTMEMORY_SECRET/g" \
+  values/infra/values-mcp-gateway.yaml > /tmp/values-mcp-gateway-local.yaml
+
+helm upgrade --install mcp-gateway ./charts/mcp-gateway \
+  -n mcp-gateway \
+  -f /tmp/values-mcp-gateway-local.yaml
+```
+
+## Secret Rotation
+
+1. Generate new secret: `openssl rand -base64 32`
+2. Update GitHub Secret: `AGENTMEMORY_SECRET`
+3. Trigger deployment (push to main or manual workflow dispatch)
+4. Both agentmemory and mcp-gateway will restart with new secret
+
+## Verification
+
+```bash
+# Check agentmemory has the secret
+kubectl exec -it deployment/agentmemory -n mcp-gateway -- env | grep AGENTMEMORY_SECRET
+
+# Check mcp-gateway backend config
+kubectl exec -it deployment/mcp-gateway -n mcp-gateway -- cat /config.yaml | grep -A 5 agentmemory
+
+# Test authenticated access
+kubectl run -it --rm curl --image=curlimages/curl -n mcp-gateway -- \
+  curl -H "Authorization: Bearer $SECRET" \
+  http://agentmemory.mcp-gateway.svc.cluster.local:3111/agentmemory/health
+```

--- a/charts/agentmemory/IMPLEMENTATION_SUMMARY.md
+++ b/charts/agentmemory/IMPLEMENTATION_SUMMARY.md
@@ -1,0 +1,347 @@
+# AgentMemory Authentication Implementation Summary
+
+## What Was Done
+
+Implemented auto-generated authentication for AgentMemory Helm chart with GitHub Actions integration for mcp-gateway.
+
+## Files Changed
+
+### AgentMemory Chart
+
+1. **`charts/agentmemory/values.yaml`**
+   - Added `auth` configuration block
+   - Default: `auth.enabled=true`, `auth.autoGenerate=true`
+   - Added `env.AGENTMEMORY_VIEWER_HOST: "0.0.0.0"`
+
+2. **`charts/agentmemory/templates/secret.yaml`** (new)
+   - Auto-generates 32-char random secret
+   - Uses `helm.sh/resource-policy: keep` annotation
+   - Secret name: `<release>-auth`
+
+3. **`charts/agentmemory/templates/deployment.yaml`**
+   - Injects `AGENTMEMORY_SECRET` from secret when auth enabled
+   - Sets `AGENTMEMORY_VIEWER_HOST` when auth enabled
+   - Conditionally disables viewerProxy sidecar
+
+4. **`charts/agentmemory/templates/ingress.yaml`**
+   - Only renders when `auth.enabled=true`
+
+5. **`charts/agentmemory/templates/ingress-tcp.yaml`**
+   - Only renders when `auth.enabled=false`
+
+6. **`charts/agentmemory/README.md`**
+   - Added authentication parameters table
+   - Updated security section
+
+### mcp-gateway Chart
+
+1. **`charts/mcp-gateway/values.yaml`**
+   - Added `gateway.agentmemory.secret` (injected via GitHub Actions)
+   - Added `gateway.agentmemory.url`
+
+2. **`charts/mcp-gateway/templates/deployment.yaml`**
+   - Injects `AGENTMEMORY_SECRET` and `AGENTMEMORY_URL` env vars
+   - Only when `gateway.agentmemory.secret` is set
+
+### Documentation
+
+1. **`AGENTMEMORY_AUTH_INTEGRATION.md`** (new)
+   - Comprehensive integration guide
+   - Three implementation options
+   - Troubleshooting section
+
+2. **`GITHUB_ACTIONS_DEPLOYMENT.md`** (new)
+   - Complete GitHub Actions workflow examples
+   - Secret rotation procedures
+   - Local development guide
+   - Security best practices
+
+3. **`IMPLEMENTATION_SUMMARY.md`** (this file)
+
+## How It Works
+
+### Architecture
+
+```
+┌──────────────────────────────┐
+│  GitHub Actions Secret       │
+│  AGENTMEMORY_SECRET          │
+└───────────┬──────────────────┘
+            │
+            ├─────────────────────┐
+            │                     │
+            ▼                     ▼
+    ┌───────────────┐     ┌──────────────┐
+    │ AgentMemory   │     │ mcp-gateway  │
+    │ Deployment    │     │ Deployment   │
+    ├───────────────┤     ├──────────────┤
+    │ --set-string  │     │ --set-string │
+    │ auth.secret=  │     │ gateway.     │
+    │ $SECRET       │     │ agentmemory. │
+    │               │     │ secret=$SEC  │
+    └───────┬───────┘     └──────┬───────┘
+            │                    │
+            ▼                    │
+    ┌───────────────┐            │
+    │ Pod: agentmem │            │
+    │ ENV:          │            │
+    │ AGENTMEMORY_  │            │
+    │ SECRET=xxx    │◄───────────┤
+    │               │    HTTP w/ │
+    │ API: :3111    │    Bearer  │
+    │ (auth req'd)  │    Token   │
+    └───────────────┘            │
+                                 │
+                         ┌───────▼───────┐
+                         │ Pod: mcp-gw   │
+                         │ ENV:          │
+                         │ AGENTMEMORY_  │
+                         │ SECRET=xxx    │
+                         └───────────────┘
+```
+
+### Deployment Flow
+
+1. **Generate Secret**: `openssl rand -base64 32`
+2. **Store in GitHub**: Settings → Secrets → `AGENTMEMORY_SECRET`
+3. **Deploy AgentMemory**: Inject secret via `--set-string auth.secret="${{ secrets.AGENTMEMORY_SECRET }}"`
+4. **Deploy mcp-gateway**: Inject same secret via `--set-string gateway.agentmemory.secret="${{ secrets.AGENTMEMORY_SECRET }}"`
+5. **mcp-gateway authenticates**: Uses env var `AGENTMEMORY_SECRET` as Bearer token
+
+## Key Design Decisions
+
+### Why GitHub Actions Secrets?
+
+**Rejected Approaches:**
+- ❌ **Auto-generated K8s Secret + secretRef**: Tight coupling, RBAC complexity
+- ❌ **Separate secrets**: Sync issues, violates DRY
+- ❌ **ServiceAccount tokens**: Not supported by AgentMemory v0.11.2
+
+**Selected Approach:**
+- ✅ **GitHub Actions Secret Injection**: Single source of truth, GitOps-friendly, no coupling
+
+### Why Default Auth to Enabled?
+
+**Previous state**: `auth.enabled=false` (legacy no-auth mode)
+- Required socat sidecar hack
+- No protection for API or viewer
+- Confusing documentation
+
+**New state**: `auth.enabled=true` by default
+- Secure by default
+- Standard HTTP ingress
+- No sidecar complexity
+- Opt-in to no-auth if needed
+
+### Why Not Commit Secrets to values.yaml?
+
+**Security principle**: Secrets should never be in version control.
+
+**Implementation**:
+- `values.yaml` has `secret: ""` (empty default)
+- Secrets injected at deployment time via `--set-string`
+- `.gitignore` protects local `values.local.yaml` files
+
+## Usage Examples
+
+### Deploy with GitHub Actions (Production)
+
+```yaml
+# .github/workflows/deploy.yml
+- name: Deploy Stack
+  run: |
+    helm upgrade --install agentmemory ./charts/agentmemory \
+      --namespace mcp-gateway \
+      --create-namespace \
+      --set auth.enabled=true \
+      --set auth.autoGenerate=false \
+      --set-string auth.secret="${{ secrets.AGENTMEMORY_SECRET }}"
+    
+    helm upgrade --install mcp-gateway ./charts/mcp-gateway \
+      --namespace mcp-gateway \
+      --set-string gateway.agentmemory.secret="${{ secrets.AGENTMEMORY_SECRET }}"
+```
+
+### Deploy Locally (Development)
+
+```bash
+# Set in environment
+export AGENTMEMORY_SECRET="local-dev-secret-do-not-use-in-prod"
+
+# Deploy
+helm upgrade --install agentmemory ./charts/agentmemory \
+  -n mcp-gateway --create-namespace \
+  --set auth.enabled=true \
+  --set auth.autoGenerate=false \
+  --set-string auth.secret="$AGENTMEMORY_SECRET"
+
+helm upgrade --install mcp-gateway ./charts/mcp-gateway \
+  -n mcp-gateway \
+  --set-string gateway.agentmemory.secret="$AGENTMEMORY_SECRET"
+```
+
+### Disable Auth (Legacy Mode)
+
+```bash
+helm upgrade --install agentmemory ./charts/agentmemory \
+  -n mcp-gateway \
+  --set auth.enabled=false \
+  --set viewerProxy.enabled=true \
+  --set ingressTCP.enabled=true \
+  --set ingress.enabled=false
+```
+
+## Testing
+
+### 1. Verify Secret Injection
+
+```bash
+# AgentMemory pod
+kubectl exec -it deployment/agentmemory -n mcp-gateway -- env | grep AGENTMEMORY_SECRET
+
+# mcp-gateway pod
+kubectl exec -it deployment/mcp-gateway -n mcp-gateway -- env | grep AGENTMEMORY_SECRET
+
+# Both should show the same value
+```
+
+### 2. Test Authenticated Access
+
+```bash
+# Get secret from GitHub (or local env)
+SECRET="${AGENTMEMORY_SECRET}"
+
+# Test from outside cluster
+kubectl run -it --rm curl --image=curlimages/curl -n mcp-gateway -- \
+  curl -H "Authorization: Bearer $SECRET" \
+  http://agentmemory.mcp-gateway.svc.cluster.local:3111/agentmemory/health
+
+# Should return: {"status":"healthy"}
+```
+
+### 3. Test Unauthorized Access (Should Fail)
+
+```bash
+# Without auth header
+kubectl run -it --rm curl --image=curlimages/curl -n mcp-gateway -- \
+  curl http://agentmemory.mcp-gateway.svc.cluster.local:3111/agentmemory/health
+
+# Should return: 401 Unauthorized
+```
+
+### 4. Test mcp-gateway Integration
+
+```bash
+# Check mcp-gateway logs
+kubectl logs -n mcp-gateway deployment/mcp-gateway --tail=50
+
+# Look for successful AgentMemory backend connection
+# Should see no auth errors
+```
+
+## Migration Path
+
+### From No-Auth (v1) to Auth-Enabled
+
+```bash
+# 1. Generate secret
+SECRET=$(openssl rand -base64 32)
+
+# 2. Add to GitHub Secrets: AGENTMEMORY_SECRET
+
+# 3. Redeploy AgentMemory with auth
+helm upgrade agentmemory ./charts/agentmemory \
+  -n mcp-gateway \
+  --set auth.enabled=true \
+  --set auth.autoGenerate=false \
+  --set-string auth.secret="$SECRET" \
+  --reuse-values
+
+# 4. Update mcp-gateway
+helm upgrade mcp-gateway ./charts/mcp-gateway \
+  -n mcp-gateway \
+  --set-string gateway.agentmemory.secret="$SECRET"
+
+# 5. Verify both pods restart and connect
+kubectl rollout status deployment/agentmemory -n mcp-gateway
+kubectl rollout status deployment/mcp-gateway -n mcp-gateway
+```
+
+### From Auto-Generated to GitHub Actions
+
+```bash
+# 1. Extract existing auto-generated secret
+EXISTING=$(kubectl get secret agentmemory-auth -n mcp-gateway \
+  -o jsonpath='{.data.agentmemory-secret}' | base64 -d)
+
+# 2. Add to GitHub Secrets (use $EXISTING value)
+
+# 3. Redeploy with autoGenerate=false
+helm upgrade agentmemory ./charts/agentmemory \
+  -n mcp-gateway \
+  --set auth.enabled=true \
+  --set auth.autoGenerate=false \
+  --set-string auth.secret="$EXISTING"
+
+# 4. Optional: Delete old K8s secret
+kubectl delete secret agentmemory-auth -n mcp-gateway
+```
+
+## Secret Rotation
+
+```bash
+# 1. Let AgentMemory generate a new secret
+kubectl delete secret agentmemory-auth -n mcp-gateway
+
+helm upgrade agentmemory ./charts/agentmemory \
+  -n mcp-gateway \
+  --set auth.enabled=true \
+  --set auth.autoGenerate=true
+
+# 2. Extract the new secret
+NEW_SECRET=$(kubectl get secret agentmemory-auth -n mcp-gateway \
+  -o jsonpath='{.data.agentmemory-secret}' | base64 -d)
+
+# 3. Update GitHub Secret: AGENTMEMORY_SECRET with $NEW_SECRET
+
+# 4. Trigger redeployment with token replacement
+git commit --allow-empty -m "Rotate AgentMemory secret"
+git push
+```
+
+## Security Considerations
+
+1. **Never commit secrets to git**
+   - Use `--set-string` for injection
+   - Add `values.local.yaml` to `.gitignore`
+
+2. **Use GitHub Environments for production**
+   - Requires manual approval
+   - Separates dev/staging/prod secrets
+
+3. **Enable secret scanning**
+   - GitHub Settings → Code security → Secret scanning
+
+4. **Rotate secrets regularly**
+   - Recommended: every 90 days
+   - Automated rotation: future enhancement
+
+5. **Limit secret access**
+   - GitHub: Restrict who can manage Actions secrets
+   - Kubernetes: Use RBAC to limit secret access
+
+## Next Steps
+
+1. ✅ **Implement** - Complete (this PR)
+2. 🔄 **Test** - Deploy to dev environment
+3. 📝 **Document** - Update main repo README
+4. 🚀 **Deploy** - Roll out to production
+5. 🔒 **Harden** - Add NetworkPolicies (future)
+6. 🔄 **Automate** - Secret rotation automation (future)
+
+## Related Documentation
+
+- `AGENTMEMORY_AUTH_INTEGRATION.md` - Detailed integration guide
+- `GITHUB_ACTIONS_DEPLOYMENT.md` - CI/CD examples and best practices
+- `README.md` - Chart overview and basic usage
+- `values.yaml` - All configuration options with comments

--- a/charts/agentmemory/README.md
+++ b/charts/agentmemory/README.md
@@ -77,6 +77,15 @@ helm delete agentmemory -n mcp-gateway
 | `persistence.size` | PVC size | `5Gi` |
 | `persistence.accessMode` | Access mode | `ReadWriteOnce` |
 
+### Authentication parameters
+
+| Name | Description | Value |
+|------|-------------|-------|
+| `auth.enabled` | Enable authentication for API and viewer | `true` |
+| `auth.autoGenerate` | Auto-generate a random secret on first install | `true` |
+| `auth.existingSecret` | Use an existing Kubernetes Secret | `""` |
+| `auth.secret` | Manually specify secret value (if autoGenerate=false) | `""` |
+
 ### Config parameters
 
 | Name | Description | Value |
@@ -88,6 +97,7 @@ helm delete agentmemory -n mcp-gateway
 | Name | Description | Value |
 |------|-------------|-------|
 | `env.TZ` | Timezone | `"UTC"` |
+| `env.AGENTMEMORY_VIEWER_HOST` | Viewer bind address (when auth enabled) | `"0.0.0.0"` |
 | `resources` | Resource limits/requests | `{}` |
 | `startupProbe` / `livenessProbe` / `readinessProbe` | Health probes | see `values.yaml` |
 | `nodeSelector` | Node selector | `{}` |
@@ -110,9 +120,66 @@ The image bakes in `docker/agentmemory/iii-config.yaml` (from GnorpLabs), which 
 
 Agentmemory stores its state store (`/data/state_store.db`) and stream store (`/data/stream_store`) on a single PVC mounted at `/data`. `podSecurityContext.fsGroup: 1000` matches the image's `USER node` (uid 1000) so the volume is writable without a chown init container.
 
-### Security
+### Authentication
 
-No authentication (`AGENTMEMORY_SECRET`) is configured by default -- the API and viewer are unauthenticated. This is a deliberate v1 tradeoff since agentmemory is only intended to be reachable within the trusted cluster/LAN. See the design doc for details.
+**Default:** Authentication is **enabled** by default with an auto-generated secret.
+
+The authentication secret is a bearer token (random hex string, similar to `openssl rand -hex 32` output).
+
+#### Four Ways to Provide the Secret
+
+**1. Auto-generate (default):**
+```yaml
+auth:
+  enabled: true
+  autoGenerate: true
+```
+- Generates a random secret on first install
+- Stored in K8s Secret `<release>-auth` with `helm.sh/resource-policy: keep`
+- Extract with: `kubectl get secret <release>-auth -n <namespace> -o jsonpath='{.data.agentmemory-secret}' | base64 -d`
+
+**2. Manual secret (BYO):**
+```yaml
+auth:
+  enabled: true
+  autoGenerate: false
+  secret: "your-64-char-hex-string-here"
+```
+Generate your own: `openssl rand -hex 32`
+
+**3. Token replacement (GitOps):**
+```yaml
+auth:
+  enabled: true
+  autoGenerate: false
+  secret: "__AGENTMEMORY_SECRET__"
+```
+Your CI/CD pipeline replaces `__AGENTMEMORY_SECRET__` with the actual value from secrets.
+
+**4. Existing K8s Secret:**
+```yaml
+auth:
+  enabled: true
+  existingSecret: "my-secret-name"
+```
+The secret must have a key named `agentmemory-secret`.
+
+#### Auth Enabled vs Disabled
+
+When `auth.enabled=true`:
+- REST/MCP API requires Bearer token authentication
+- Viewer requires authentication
+- Viewer binds to `0.0.0.0` (all interfaces)
+- Standard HTTP ingress is used
+
+When `auth.enabled=false` (legacy mode):
+- No authentication on API or viewer
+- Viewer binds to `127.0.0.1` (loopback only)
+- Requires socat sidecar to expose viewer
+- Uses raw TCP ingress instead of HTTP
+
+**Integration with mcp-gateway:**
+See `DEPLOYMENT.md` for sharing the secret with mcp-gateway (two patterns supported).
 
 ## Upgrading
 

--- a/charts/agentmemory/README.md
+++ b/charts/agentmemory/README.md
@@ -1,0 +1,132 @@
+# Agentmemory Helm Chart
+
+Persistent memory server for AI coding agents (REST API + MCP server + real-time viewer), built on the `iii` engine.
+
+## Introduction
+
+This chart deploys [agentmemory](https://github.com/rohitg00/agentmemory) on a Kubernetes cluster using the Helm package manager, using GnorpLabs' custom image (`ghcr.io/gnorplabs/agentmemory`, built from `GnorpLabs/docker/agentmemory`).
+
+Agentmemory is primarily consumed as a backend by `mcp-gateway` (in-cluster, over the REST/MCP API on port 3111). It also ships a real-time viewer UI (port 3113) intended for LAN access by humans.
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.0+
+- PersistentVolume provisioner support in the underlying infrastructure (`freenas-iscsi-csi` by default)
+
+## Installing the Chart
+
+To install the chart with the release name `agentmemory`:
+
+```bash
+helm install agentmemory ./charts/agentmemory -n mcp-gateway --create-namespace
+```
+
+## Uninstalling the Chart
+
+```bash
+helm delete agentmemory -n mcp-gateway
+```
+
+## Parameters
+
+### Common parameters
+
+| Name | Description | Value |
+|------|-------------|-------|
+| `replicaCount` | Number of agentmemory replicas (fixed at 1 -- file-based state store, not designed for concurrent multi-pod access) | `1` |
+| `namespace` | Informational only; actual namespace set at the helm/helmfile release level | `"mcp-gateway"` |
+
+### Image parameters
+
+| Name | Description | Value |
+|------|-------------|-------|
+| `image.repository` | agentmemory image repository | `ghcr.io/gnorplabs/agentmemory` |
+| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `image.tag` | Image tag (only `latest` is published today) | `"latest"` |
+
+### Service parameters
+
+| Name | Description | Value |
+|------|-------------|-------|
+| `service.type` | Service type | `ClusterIP` |
+| `service.ports.http` | REST API + MCP HTTP surface | `3111` |
+| `service.ports.stream` | Internal iii-engine stream worker | `3112` |
+| `service.ports.viewer` | Real-time viewer UI | `3113` |
+| `service.ports.engine` | iii-engine websocket (worker registration) | `49134` |
+| `service.ports.metrics` | Prometheus-style metrics | `9464` |
+
+### Ingress parameters
+
+| Name | Description | Value |
+|------|-------------|-------|
+| `ingress.enabled` | Enable ingress | `true` |
+| `ingress.className` | Ingress class name | `"traefik"` |
+| `ingress.annotations` | Ingress annotations | `{}` |
+| `ingress.host` | Hostname (viewer only -- see [Networking](#networking)) | `agentmemory.gnorplabs.cc` |
+| `ingress.path` | Path | `/` |
+| `ingress.pathType` | Path type | `ImplementationSpecific` |
+| `ingress.tls` | TLS configuration | `[]` |
+
+### Persistence parameters
+
+| Name | Description | Value |
+|------|-------------|-------|
+| `persistence.claimName` | Existing PVC name (optional) | `""` |
+| `persistence.storageClass` | Storage class | `"freenas-iscsi-csi"` |
+| `persistence.size` | PVC size | `5Gi` |
+| `persistence.accessMode` | Access mode | `ReadWriteOnce` |
+
+### Config parameters
+
+| Name | Description | Value |
+|------|-------------|-------|
+| `config.corsExtraOrigins` | Extra CORS allowed_origins appended to the rendered iii-config.yaml | `[]` |
+
+### Other parameters
+
+| Name | Description | Value |
+|------|-------------|-------|
+| `env.TZ` | Timezone | `"UTC"` |
+| `resources` | Resource limits/requests | `{}` |
+| `startupProbe` / `livenessProbe` / `readinessProbe` | Health probes | see `values.yaml` |
+| `nodeSelector` | Node selector | `{}` |
+| `tolerations` | Tolerations | `[]` |
+| `affinity` | Affinity rules | `{}` |
+
+## Configuration and Installation Details
+
+### Why this chart ships its own iii-config.yaml
+
+The image bakes in `docker/agentmemory/iii-config.yaml` (from GnorpLabs), which sets `host: [IP_ADDRESS]` on the `iii-http` (3111) and `iii-stream` (3112) workers. Unquoted in YAML, `[IP_ADDRESS]` parses as a one-item array, not a valid bind address. This chart renders a ConfigMap mirroring agentmemory's own known-working `iii-config.docker.yaml` (binding `0.0.0.0`) and mounts it over `/app/config.yaml`, instead of trusting the image's baked-in config. See `docs/superpowers/specs/2026-07-19-agentmemory-helmchart-design.md` in this repo for the full rationale.
+
+### Networking
+
+- **API (port 3111)** is ClusterIP-only and has no ingress. It's meant to be consumed in-cluster (e.g. by `mcp-gateway`) via the Service DNS name: `<release-name>.mcp-gateway.svc.cluster.local:3111`.
+- **Viewer (port 3113)** is the only port exposed via ingress. Its frontend proxies REST calls to the API **server-side** (the browser never calls 3111 directly), so no separate API hostname is needed for the viewer to function.
+- **Live updates** in the viewer connect directly from the browser to port 3112 via WebSocket, using client-side port arithmetic that assumes a raw `:port` URL. This does not survive being accessed through the hostname-based ingress and gracefully degrades to the viewer's existing 10s HTTP-polling fallback. This is a known upstream limitation and is not solved by this chart.
+
+### Storage
+
+Agentmemory stores its state store (`/data/state_store.db`) and stream store (`/data/stream_store`) on a single PVC mounted at `/data`. `podSecurityContext.fsGroup: 1000` matches the image's `USER node` (uid 1000) so the volume is writable without a chown init container.
+
+### Security
+
+No authentication (`AGENTMEMORY_SECRET`) is configured by default -- the API and viewer are unauthenticated. This is a deliberate v1 tradeoff since agentmemory is only intended to be reachable within the trusted cluster/LAN. See the design doc for details.
+
+## Upgrading
+
+```bash
+helm upgrade agentmemory ./charts/agentmemory -n mcp-gateway
+```
+
+## Deferred / Out of Scope for v1
+
+- Authentication (`AGENTMEMORY_SECRET`)
+- LLM/embedding provider keys (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc.) -- TODO placeholder in `values.yaml`, agentmemory runs BM25-only without them
+- `ServiceMonitor` for the metrics port (the port is exposed on the Service, but no CRD is created)
+- TLS on the viewer ingress
+
+## Support
+
+For questions or issues with agentmemory itself: [rohitg00/agentmemory](https://github.com/rohitg00/agentmemory).

--- a/charts/agentmemory/templates/_helpers.tpl
+++ b/charts/agentmemory/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "agentmemory.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "agentmemory.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "agentmemory.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "agentmemory.labels" -}}
+helm.sh/chart: {{ include "agentmemory.chart" . }}
+{{ include "agentmemory.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "agentmemory.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "agentmemory.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "agentmemory.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "agentmemory.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/agentmemory/templates/configmap.yaml
+++ b/charts/agentmemory/templates/configmap.yaml
@@ -1,3 +1,13 @@
+{{/*
+  ConfigMap is kept for CORS extra-origins injection only. The iii-config.yaml
+  that iii-engine actually reads is written by the image's entrypoint.sh at
+  /opt/agentmemory/node_modules/@agentmemory/agentmemory/dist/iii-config.yaml
+  with host: 0.0.0.0 so the pod IP is reachable for probes and Service traffic.
+
+  This ConfigMap is not mounted in the Deployment. It exists so that the chart
+  can be extended in future to inject additional CORS origins or other config
+  overrides via an init container if needed.
+*/}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -5,65 +15,9 @@ metadata:
   labels:
     {{- include "agentmemory.labels" . | nindent 4 }}
 data:
-  # Mirrors agentmemory's own known-working iii-config.docker.yaml (0.0.0.0
-  # binds) instead of the broken `host: [IP_ADDRESS]` config baked into the
-  # GnorpLabs image. See docs/superpowers/specs/2026-07-19-agentmemory-helmchart-design.md
-  # for the full rationale.
-  config.yaml: |
-    workers:
-      - name: iii-http
-        config:
-          port: {{ .Values.service.ports.http }}
-          host: 0.0.0.0
-          default_timeout: 180000
-          cors:
-            allowed_origins:
-              - "http://localhost:{{ .Values.service.ports.http }}"
-              - "http://localhost:{{ .Values.service.ports.viewer }}"
-              - "http://127.0.0.1:{{ .Values.service.ports.http }}"
-              - "http://127.0.0.1:{{ .Values.service.ports.viewer }}"
-              {{- if .Values.ingress.enabled }}
-              - "https://{{ .Values.ingress.host }}"
-              - "http://{{ .Values.ingress.host }}"
-              {{- end }}
-              {{- range .Values.config.corsExtraOrigins }}
-              - {{ . | quote }}
-              {{- end }}
-            allowed_methods: [GET, POST, PUT, DELETE, OPTIONS]
-      - name: iii-state
-        config:
-          adapter:
-            name: kv
-            config:
-              store_method: file_based
-              file_path: /data/state_store.db
-      - name: iii-queue
-        config:
-          adapter:
-            name: builtin
-      - name: iii-pubsub
-        config:
-          adapter:
-            name: local
-      - name: iii-cron
-        config:
-          adapter:
-            name: kv
-      - name: iii-stream
-        config:
-          port: {{ .Values.service.ports.stream }}
-          host: 0.0.0.0
-          adapter:
-            name: kv
-            config:
-              store_method: file_based
-              file_path: /data/stream_store
-      - name: iii-observability
-        config:
-          enabled: true
-          service_name: agentmemory
-          exporter: memory
-          sampling_ratio: 0.1
-          metrics_enabled: true
-          logs_enabled: true
-          logs_console_output: false
+  # Extra CORS origins for the iii-http worker, if needed.
+  # Currently unused -- the entrypoint.sh writes a static config.
+  corsExtraOrigins: |
+    {{- range .Values.config.corsExtraOrigins }}
+    - {{ . | quote }}
+    {{- end }}

--- a/charts/agentmemory/templates/configmap.yaml
+++ b/charts/agentmemory/templates/configmap.yaml
@@ -1,0 +1,69 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "agentmemory.fullname" . }}-config
+  labels:
+    {{- include "agentmemory.labels" . | nindent 4 }}
+data:
+  # Mirrors agentmemory's own known-working iii-config.docker.yaml (0.0.0.0
+  # binds) instead of the broken `host: [IP_ADDRESS]` config baked into the
+  # GnorpLabs image. See docs/superpowers/specs/2026-07-19-agentmemory-helmchart-design.md
+  # for the full rationale.
+  config.yaml: |
+    workers:
+      - name: iii-http
+        config:
+          port: {{ .Values.service.ports.http }}
+          host: 0.0.0.0
+          default_timeout: 180000
+          cors:
+            allowed_origins:
+              - "http://localhost:{{ .Values.service.ports.http }}"
+              - "http://localhost:{{ .Values.service.ports.viewer }}"
+              - "http://127.0.0.1:{{ .Values.service.ports.http }}"
+              - "http://127.0.0.1:{{ .Values.service.ports.viewer }}"
+              {{- if .Values.ingress.enabled }}
+              - "https://{{ .Values.ingress.host }}"
+              - "http://{{ .Values.ingress.host }}"
+              {{- end }}
+              {{- range .Values.config.corsExtraOrigins }}
+              - {{ . | quote }}
+              {{- end }}
+            allowed_methods: [GET, POST, PUT, DELETE, OPTIONS]
+      - name: iii-state
+        config:
+          adapter:
+            name: kv
+            config:
+              store_method: file_based
+              file_path: /data/state_store.db
+      - name: iii-queue
+        config:
+          adapter:
+            name: builtin
+      - name: iii-pubsub
+        config:
+          adapter:
+            name: local
+      - name: iii-cron
+        config:
+          adapter:
+            name: kv
+      - name: iii-stream
+        config:
+          port: {{ .Values.service.ports.stream }}
+          host: 0.0.0.0
+          adapter:
+            name: kv
+            config:
+              store_method: file_based
+              file_path: /data/stream_store
+      - name: iii-observability
+        config:
+          enabled: true
+          service_name: agentmemory
+          exporter: memory
+          sampling_ratio: 0.1
+          metrics_enabled: true
+          logs_enabled: true
+          logs_console_output: false

--- a/charts/agentmemory/templates/deployment.yaml
+++ b/charts/agentmemory/templates/deployment.yaml
@@ -39,12 +39,17 @@ spec:
           env:
             - name: TZ
               value: {{ .Values.env.TZ | quote }}
-            # Host headers the viewer trusts (gate-free; needs no secret).
-            # Intentionally NO AGENTMEMORY_SECRET (would auth-gate the MCP API)
-            # and NO AGENTMEMORY_VIEWER_HOST (non-loopback fatally requires the
-            # secret). The viewer stays loopback; the socat sidecar re-exposes it.
             - name: VIEWER_ALLOWED_HOSTS
               value: {{ .Values.env.VIEWER_ALLOWED_HOSTS | quote }}
+            {{- if .Values.auth.enabled }}
+            - name: AGENTMEMORY_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.auth.existingSecret | default (printf "%s-auth" (include "agentmemory.fullname" .)) }}
+                  key: agentmemory-secret
+            - name: AGENTMEMORY_VIEWER_HOST
+              value: {{ .Values.env.AGENTMEMORY_VIEWER_HOST | quote }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.ports.http }}
@@ -72,7 +77,7 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data
-        {{- if .Values.viewerProxy.enabled }}
+        {{- if and .Values.viewerProxy.enabled (not .Values.auth.enabled) }}
         # socat sidecar: the no-secret viewer binds loopback (127.0.0.1:3113) only.
         # Containers in a pod share the network namespace, so this sidecar can
         # reach that loopback listener and re-expose it on the pod IP. The

--- a/charts/agentmemory/templates/deployment.yaml
+++ b/charts/agentmemory/templates/deployment.yaml
@@ -68,17 +68,10 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data
-            - name: config
-              mountPath: /app/config.yaml
-              subPath: config.yaml
-              readOnly: true
       volumes:
         - name: data
           persistentVolumeClaim:
             claimName: {{ .Values.persistence.claimName | default (printf "%s-data" (include "agentmemory.fullname" .)) }}
-        - name: config
-          configMap:
-            name: {{ include "agentmemory.fullname" . }}-config
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/agentmemory/templates/deployment.yaml
+++ b/charts/agentmemory/templates/deployment.yaml
@@ -39,11 +39,12 @@ spec:
           env:
             - name: TZ
               value: {{ .Values.env.TZ | quote }}
-            # Viewer intentionally stays on loopback (no AGENTMEMORY_VIEWER_HOST set).
-            # v0.9.28 enforces that non-loopback viewer bind requires AGENTMEMORY_SECRET.
-            # Access the viewer via: kubectl port-forward -n mcp-gateway svc/agentmemory 3113:3113
-            # TODO: wire optional LLM/embedding provider keys here via
-            # .Values.providerSecrets.existingSecret once needed.
+            # Host headers the viewer trusts (gate-free; needs no secret).
+            # Intentionally NO AGENTMEMORY_SECRET (would auth-gate the MCP API)
+            # and NO AGENTMEMORY_VIEWER_HOST (non-loopback fatally requires the
+            # secret). The viewer stays loopback; the socat sidecar re-exposes it.
+            - name: VIEWER_ALLOWED_HOSTS
+              value: {{ .Values.env.VIEWER_ALLOWED_HOSTS | quote }}
           ports:
             - name: http
               containerPort: {{ .Values.service.ports.http }}
@@ -71,6 +72,72 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data
+        {{- if .Values.viewerProxy.enabled }}
+        # socat sidecar: the no-secret viewer binds loopback (127.0.0.1:3113) only.
+        # Containers in a pod share the network namespace, so this sidecar can
+        # reach that loopback listener and re-expose it on the pod IP. The
+        # Service's viewer port targets this container (viewer-proxy), which
+        # Traefik's agentmemory TCP entrypoint routes to.
+        - name: viewer-proxy
+          image: {{ .Values.viewerProxy.image | quote }}
+          args:
+            - "TCP-LISTEN:{{ .Values.viewerProxy.listenPort }},fork,reuseaddr"
+            - "TCP:127.0.0.1:{{ .Values.service.ports.viewer }}"
+          ports:
+            - name: viewer-proxy
+              containerPort: {{ .Values.viewerProxy.listenPort }}
+              protocol: TCP
+          {{- with .Values.viewerProxy.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
+        {{- if .Values.mcpBridge.enabled }}
+        # MCP bridge: agentmemory has no MCP-over-HTTP endpoint; its real MCP
+        # interface is the stdio server (`agentmemory mcp`). supergateway wraps
+        # it as Streamable HTTP at :{{ .Values.mcpBridge.port }}/mcp for
+        # mcp-gateway. Reuses the app image (node + CLI already present). The
+        # stdio server reaches the in-pod REST API on localhost:3111.
+        - name: mcp-bridge
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["sh", "-c"]
+          args:
+            - >-
+              cd /tmp &&
+              exec npx -y supergateway@{{ .Values.mcpBridge.supergatewayVersion }}
+              --stdio "agentmemory mcp"
+              --outputTransport streamableHttp
+              --port {{ .Values.mcpBridge.port }}
+              --healthEndpoint /healthz
+          env:
+            - name: TZ
+              value: {{ .Values.env.TZ | quote }}
+          ports:
+            - name: mcp-bridge
+              containerPort: {{ .Values.mcpBridge.port }}
+              protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: mcp-bridge
+            # npx downloads supergateway on first start; allow ample time.
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 24
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: mcp-bridge
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          {{- with .Values.mcpBridge.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
       volumes:
         - name: data
           persistentVolumeClaim:

--- a/charts/agentmemory/templates/deployment.yaml
+++ b/charts/agentmemory/templates/deployment.yaml
@@ -39,12 +39,9 @@ spec:
           env:
             - name: TZ
               value: {{ .Values.env.TZ | quote }}
-            # Bind the viewer to all interfaces so Traefik can reach the pod IP.
-            - name: AGENTMEMORY_VIEWER_HOST
-              value: "0.0.0.0"
-            # Allow the ingress hostname as a valid Host header.
-            - name: VIEWER_ALLOWED_HOSTS
-              value: "localhost:3113,127.0.0.1:3113,{{ .Values.ingress.host }}"
+            # Viewer intentionally stays on loopback (no AGENTMEMORY_VIEWER_HOST set).
+            # v0.9.28 enforces that non-loopback viewer bind requires AGENTMEMORY_SECRET.
+            # Access the viewer via: kubectl port-forward -n mcp-gateway svc/agentmemory 3113:3113
             # TODO: wire optional LLM/embedding provider keys here via
             # .Values.providerSecrets.existingSecret once needed.
           ports:

--- a/charts/agentmemory/templates/deployment.yaml
+++ b/charts/agentmemory/templates/deployment.yaml
@@ -39,6 +39,12 @@ spec:
           env:
             - name: TZ
               value: {{ .Values.env.TZ | quote }}
+            # Bind the viewer to all interfaces so Traefik can reach the pod IP.
+            - name: AGENTMEMORY_VIEWER_HOST
+              value: "0.0.0.0"
+            # Allow the ingress hostname as a valid Host header.
+            - name: VIEWER_ALLOWED_HOSTS
+              value: "localhost:3113,127.0.0.1:3113,{{ .Values.ingress.host }}"
             # TODO: wire optional LLM/embedding provider keys here via
             # .Values.providerSecrets.existingSecret once needed.
           ports:

--- a/charts/agentmemory/templates/deployment.yaml
+++ b/charts/agentmemory/templates/deployment.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "agentmemory.fullname" . }}
+  labels:
+    {{- include "agentmemory.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "agentmemory.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "agentmemory.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "agentmemory.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: TZ
+              value: {{ .Values.env.TZ | quote }}
+            # TODO: wire optional LLM/embedding provider keys here via
+            # .Values.providerSecrets.existingSecret once needed.
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.ports.http }}
+              protocol: TCP
+            - name: stream
+              containerPort: {{ .Values.service.ports.stream }}
+              protocol: TCP
+            - name: viewer
+              containerPort: {{ .Values.service.ports.viewer }}
+              protocol: TCP
+            - name: engine
+              containerPort: {{ .Values.service.ports.engine }}
+              protocol: TCP
+            - name: metrics
+              containerPort: {{ .Values.service.ports.metrics }}
+              protocol: TCP
+          startupProbe:
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: config
+              mountPath: /app/config.yaml
+              subPath: config.yaml
+              readOnly: true
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.claimName | default (printf "%s-data" (include "agentmemory.fullname" .)) }}
+        - name: config
+          configMap:
+            name: {{ include "agentmemory.fullname" . }}-config
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/agentmemory/templates/ingress-tcp.yaml
+++ b/charts/agentmemory/templates/ingress-tcp.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingressTCP.enabled -}}
+{{- if and .Values.ingressTCP.enabled (not .Values.auth.enabled) -}}
 {{- $fullName := include "agentmemory.fullname" . -}}
 {{/*
   Raw TCP exposure of the viewer through Traefik -- no auth, no secret.

--- a/charts/agentmemory/templates/ingress-tcp.yaml
+++ b/charts/agentmemory/templates/ingress-tcp.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.ingressTCP.enabled -}}
+{{- $fullName := include "agentmemory.fullname" . -}}
+{{/*
+  Raw TCP exposure of the viewer through Traefik -- no auth, no secret.
+
+  Why TCP and not the HTTP ingress: agentmemory v0.11.2 only allows a
+  non-loopback viewer bind when AGENTMEMORY_SECRET is set, and that same
+  secret also auth-gates the whole REST/MCP API (which must stay open for
+  mcp-gateway). Raw TCP entrypoints + the socat sidecar avoid both.
+
+  PREREQUISITE: the global k3s Traefik HelmChartConfig must define the
+  entrypoints named below (see GnorpLabs/k3s/traefik/traefik-config.yaml).
+
+  - viewer route  -> Service viewer port (socat sidecar -> loopback viewer)
+  - ws route      -> Service stream port (iii-stream binds all interfaces)
+  HostSNI(`*`) is required for non-TLS TCP routers.
+*/}}
+apiVersion: traefik.io/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: {{ $fullName }}-viewer
+  labels:
+    {{- include "agentmemory.labels" . | nindent 4 }}
+spec:
+  entryPoints:
+    - {{ .Values.ingressTCP.viewerEntryPoint }}
+  routes:
+    - match: HostSNI(`*`)
+      services:
+        - name: {{ $fullName }}
+          port: {{ .Values.service.ports.viewer }}
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: {{ $fullName }}-viewer-ws
+  labels:
+    {{- include "agentmemory.labels" . | nindent 4 }}
+spec:
+  entryPoints:
+    - {{ .Values.ingressTCP.wsEntryPoint }}
+  routes:
+    - match: HostSNI(`*`)
+      services:
+        - name: {{ $fullName }}
+          port: {{ .Values.service.ports.stream }}
+{{- end }}

--- a/charts/agentmemory/templates/ingress.yaml
+++ b/charts/agentmemory/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled -}}
+{{- if and .Values.ingress.enabled .Values.auth.enabled -}}
 {{- $fullName := include "agentmemory.fullname" . -}}
 {{- $svcPort := .Values.service.ports.viewer -}}
 apiVersion: networking.k8s.io/v1

--- a/charts/agentmemory/templates/ingress.yaml
+++ b/charts/agentmemory/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "agentmemory.fullname" . -}}
+{{- $svcPort := .Values.service.ports.viewer -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "agentmemory.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+{{- end }}

--- a/charts/agentmemory/templates/pvc.yaml
+++ b/charts/agentmemory/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if not .Values.persistence.claimName -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "agentmemory.fullname" . }}-data
+  labels:
+    {{- include "agentmemory.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/charts/agentmemory/templates/secret.yaml
+++ b/charts/agentmemory/templates/secret.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.auth.enabled (not .Values.auth.existingSecret) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "agentmemory.fullname" . }}-auth
+  labels:
+    {{- include "agentmemory.labels" . | nindent 4 }}
+  {{- if .Values.auth.autoGenerate }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{- end }}
+type: Opaque
+data:
+  {{- if .Values.auth.autoGenerate }}
+  agentmemory-secret: {{ randAlphaNum 32 | b64enc | quote }}
+  {{- else }}
+  agentmemory-secret: {{ .Values.auth.secret | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/agentmemory/templates/service.yaml
+++ b/charts/agentmemory/templates/service.yaml
@@ -16,7 +16,13 @@ spec:
       protocol: TCP
       name: stream
     - port: {{ .Values.service.ports.viewer }}
+      {{- if .Values.viewerProxy.enabled }}
+      # Route through the socat sidecar: the no-secret viewer binds loopback
+      # inside the pod, so the pod-IP-facing listener is the sidecar.
+      targetPort: viewer-proxy
+      {{- else }}
       targetPort: viewer
+      {{- end }}
       protocol: TCP
       name: viewer
     - port: {{ .Values.service.ports.engine }}
@@ -27,5 +33,13 @@ spec:
       targetPort: metrics
       protocol: TCP
       name: metrics
+    {{- if .Values.mcpBridge.enabled }}
+    # Streamable HTTP MCP endpoint (supergateway sidecar wrapping the stdio
+    # `agentmemory mcp` server). Consumed in-cluster by mcp-gateway.
+    - port: {{ .Values.mcpBridge.port }}
+      targetPort: mcp-bridge
+      protocol: TCP
+      name: mcp
+    {{- end }}
   selector:
     {{- include "agentmemory.selectorLabels" . | nindent 4 }}

--- a/charts/agentmemory/templates/service.yaml
+++ b/charts/agentmemory/templates/service.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "agentmemory.fullname" . }}
+  labels:
+    {{- include "agentmemory.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.ports.http }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: {{ .Values.service.ports.stream }}
+      targetPort: stream
+      protocol: TCP
+      name: stream
+    - port: {{ .Values.service.ports.viewer }}
+      targetPort: viewer
+      protocol: TCP
+      name: viewer
+    - port: {{ .Values.service.ports.engine }}
+      targetPort: engine
+      protocol: TCP
+      name: engine
+    - port: {{ .Values.service.ports.metrics }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  selector:
+    {{- include "agentmemory.selectorLabels" . | nindent 4 }}

--- a/charts/agentmemory/templates/serviceaccount.yaml
+++ b/charts/agentmemory/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "agentmemory.serviceAccountName" . }}
+  labels:
+    {{- include "agentmemory.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/agentmemory/values.yaml
+++ b/charts/agentmemory/values.yaml
@@ -51,27 +51,11 @@ service:
     # Prometheus-style metrics.
     metrics: 9464
 
-# HTTP ingress for the viewer is DISABLED by design. An HTTP (hostname-based)
-# ingress would require the viewer to bind non-loopback, which agentmemory
-# v0.11.2 only allows with AGENTMEMORY_SECRET set -- and that same secret also
-# turns on auth for the whole REST/MCP API, which this deployment must keep
-# OPEN (mcp-gateway consumes it unauthenticated in-cluster).
-#
-# Instead the viewer is exposed via raw Traefik TCP entrypoints (see
-# templates/ingress-tcp.yaml + ingressTCP below). With no AGENTMEMORY_SECRET
-# the viewer binds loopback INSIDE the pod, so a small socat sidecar
-# (viewerProxy below) re-exposes it on the pod IP: Traefik TCP :3113 ->
-# Service viewer port -> sidecar :13113 -> 127.0.0.1:3113 (shared pod netns).
-# The live-update WebSocket worker (iii-stream, :3112) already binds
-# all-interfaces, so its TCP route goes straight to the pod. Result:
-#   http://<lan-host>:3113   viewer UI + server-side REST proxy (no auth)
-#   ws://<lan-host>:3112     live updates
-#
-# PREREQUISITE (one-time, global Traefik config -- not this chart): the k3s
-# Traefik HelmChartConfig must define TCP entrypoints "agentmemory" (:3113)
-# and "agentmemory-ws" (:3112). See GnorpLabs/k3s/traefik/traefik-config.yaml.
+# Ingress configuration for the viewer UI.
+# With auth enabled (auth.enabled=true), standard HTTP ingress is used.
+# With auth disabled, raw TCP ingress is required (see ingressTCP below).
 ingress:
-  enabled: false
+  enabled: true
   className: "traefik"
   annotations: {}
   host: "agentmemory.gnorplabs.cc"
@@ -79,20 +63,21 @@ ingress:
   pathType: ImplementationSpecific
   tls: []
 
-# Raw TCP exposure of the viewer through Traefik (no auth, no secret).
-# Renders two IngressRouteTCP objects targeting this chart's Service.
+# Raw TCP exposure of the viewer through Traefik (legacy/no-auth mode).
+# Only used when auth.enabled=false. When auth is enabled, use standard
+# HTTP ingress above instead.
 ingressTCP:
-  enabled: true
+  enabled: false
   # Traefik entrypoint names (must exist in the global Traefik config).
   viewerEntryPoint: "agentmemory"
   wsEntryPoint: "agentmemory-ws"
 
-# socat sidecar that forwards pod-IP traffic to the viewer's loopback-only
-# listener (127.0.0.1:3113). Listens on containerPort 13113; the Service's
-# viewer port targets it. Required because the no-secret viewer refuses to
-# bind non-loopback (see ingress comment above).
+# socat sidecar for no-auth mode (auth.enabled=false).
+# When auth is disabled, the viewer binds loopback-only (127.0.0.1:3113).
+# This sidecar exposes it on the pod network interface.
+# Automatically disabled when auth.enabled=true.
 viewerProxy:
-  enabled: true
+  enabled: false
   image: "alpine/socat:latest"
   listenPort: 13113
   resources:
@@ -143,21 +128,58 @@ config:
   # the ingress viewer hostname (auto-included when ingress.enabled).
   corsExtraOrigins: []
 
-# No AGENTMEMORY_SECRET and no AGENTMEMORY_VIEWER_HOST -- intentional.
-# With the secret unset, agentmemory v0.11.2 serves the entire REST/MCP API
-# fully open (checkAuth returns open when the secret is falsy), which is what
-# mcp-gateway needs for zero-auth in-cluster consumption. The viewer binds
-# loopback inside the pod and is re-exposed by the socat sidecar (viewerProxy).
-# Do NOT set AGENTMEMORY_SECRET: it would auth-gate the MCP API as a side
-# effect. Do NOT set AGENTMEMORY_VIEWER_HOST: a non-loopback value makes the
-# process fatally exit without a secret.
+# Authentication secret for the REST/MCP API and viewer.
+# The secret is a bearer token (random hex string, e.g., output of `openssl rand -hex 32`).
+# When enabled, authentication is required for both the API and viewer.
 #
-# VIEWER_ALLOWED_HOSTS extends the viewer's Host-header allowlist (the viewer
-# 403s "forbidden host" otherwise). It is gate-free -- setting it does NOT
-# require the secret. Must contain every host:port the browser will use.
+# Four ways to provide the secret:
+#
+# 1. Auto-generate (recommended for initial setup):
+#    auth:
+#      enabled: true
+#      autoGenerate: true
+#    A random secret is generated and stored in K8s Secret "<release>-auth".
+#    Extract it with: kubectl get secret <release>-auth -n <namespace> -o jsonpath='{.data.agentmemory-secret}' | base64 -d
+#
+# 2. Manual secret (generate your own):
+#    auth:
+#      enabled: true
+#      autoGenerate: false
+#      secret: "your-64-char-hex-string-here"
+#    Generate with: openssl rand -hex 32
+#
+# 3. Token replacement (GitOps pattern):
+#    auth:
+#      enabled: true
+#      autoGenerate: false
+#      secret: "__AGENTMEMORY_SECRET__"
+#    Your CI/CD replaces __AGENTMEMORY_SECRET__ with the actual value from secrets.
+#
+# 4. Existing K8s Secret:
+#    auth:
+#      enabled: true
+#      existingSecret: "my-secret-name"
+#    The secret must have a key named "agentmemory-secret" containing the bearer token.
+#
+auth:
+  enabled: true
+  # Auto-generate a random secret on first install (stored in k8s Secret).
+  # Set to false to provide your own secret via one of the methods above.
+  autoGenerate: true
+  # Use an existing K8s Secret instead of auto-generating or providing inline.
+  # If set, autoGenerate and secret are ignored.
+  # The secret must contain a key named "agentmemory-secret".
+  existingSecret: ""
+  # Manually specify the secret value (only used if autoGenerate=false and existingSecret="").
+  # Can be a raw value, or a token like "__AGENTMEMORY_SECRET__" for replacement.
+  secret: ""
+
 env:
   TZ: "UTC"
   VIEWER_ALLOWED_HOSTS: "localhost:3113,agentmemory.gnorplabs.cc:3113"
+  # When auth is enabled, the viewer can bind to all interfaces.
+  # When disabled, viewer binds loopback only (requires socat sidecar).
+  AGENTMEMORY_VIEWER_HOST: "0.0.0.0"
 
 # TODO: wire optional LLM/embedding provider keys (ANTHROPIC_API_KEY,
 # OPENAI_API_KEY, GEMINI_API_KEY, VOYAGE_API_KEY, etc.) via an

--- a/charts/agentmemory/values.yaml
+++ b/charts/agentmemory/values.yaml
@@ -51,20 +51,25 @@ service:
     # Prometheus-style metrics.
     metrics: 9464
 
-# Only the viewer is exposed via ingress. The viewer's frontend proxies REST
-# calls to the API server-side (browser never calls port 3111 directly), so
-# the API needs no public hostname of its own.
+# HTTP ingress for the viewer is DISABLED by design. An HTTP (hostname-based)
+# ingress would require the viewer to bind non-loopback, which agentmemory
+# v0.11.2 only allows with AGENTMEMORY_SECRET set -- and that same secret also
+# turns on auth for the whole REST/MCP API, which this deployment must keep
+# OPEN (mcp-gateway consumes it unauthenticated in-cluster).
 #
-# Note: live-update WebSocket connections (port 3112) are made directly from
-# the browser using client-side port arithmetic that assumes a raw `:port`
-# URL. This will not survive being accessed through this hostname-based
-# ingress and gracefully degrades to the viewer's existing 10s HTTP-polling
-# fallback -- a known upstream limitation, not something this chart solves.
-# Viewer ingress disabled: agentmemory v0.9.28 requires AGENTMEMORY_SECRET when
-# binding the viewer to non-loopback. Since this deployment is intentionally
-# unauthenticated, the viewer stays on loopback and is accessed via:
-#   kubectl port-forward -n mcp-gateway svc/agentmemory 3113:3113
-# then open http://localhost:3113 in your browser.
+# Instead the viewer is exposed via raw Traefik TCP entrypoints (see
+# templates/ingress-tcp.yaml + ingressTCP below). With no AGENTMEMORY_SECRET
+# the viewer binds loopback INSIDE the pod, so a small socat sidecar
+# (viewerProxy below) re-exposes it on the pod IP: Traefik TCP :3113 ->
+# Service viewer port -> sidecar :13113 -> 127.0.0.1:3113 (shared pod netns).
+# The live-update WebSocket worker (iii-stream, :3112) already binds
+# all-interfaces, so its TCP route goes straight to the pod. Result:
+#   http://<lan-host>:3113   viewer UI + server-side REST proxy (no auth)
+#   ws://<lan-host>:3112     live updates
+#
+# PREREQUISITE (one-time, global Traefik config -- not this chart): the k3s
+# Traefik HelmChartConfig must define TCP entrypoints "agentmemory" (:3113)
+# and "agentmemory-ws" (:3112). See GnorpLabs/k3s/traefik/traefik-config.yaml.
 ingress:
   enabled: false
   className: "traefik"
@@ -73,9 +78,45 @@ ingress:
   path: /
   pathType: ImplementationSpecific
   tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
+
+# Raw TCP exposure of the viewer through Traefik (no auth, no secret).
+# Renders two IngressRouteTCP objects targeting this chart's Service.
+ingressTCP:
+  enabled: true
+  # Traefik entrypoint names (must exist in the global Traefik config).
+  viewerEntryPoint: "agentmemory"
+  wsEntryPoint: "agentmemory-ws"
+
+# socat sidecar that forwards pod-IP traffic to the viewer's loopback-only
+# listener (127.0.0.1:3113). Listens on containerPort 13113; the Service's
+# viewer port targets it. Required because the no-secret viewer refuses to
+# bind non-loopback (see ingress comment above).
+viewerProxy:
+  enabled: true
+  image: "alpine/socat:latest"
+  listenPort: 13113
+  resources:
+    requests: {cpu: 5m, memory: 8Mi}
+    limits: {cpu: 50m, memory: 32Mi}
+
+# MCP bridge sidecar: agentmemory's HTTP server exposes NO MCP JSON-RPC
+# endpoint (its /agentmemory/mcp/* paths are custom REST wrappers). The real
+# MCP interface is the stdio server (`agentmemory mcp`, aka @agentmemory/mcp).
+# This sidecar reuses the app image (node + agentmemory CLI already inside)
+# and runs supergateway to wrap that stdio server as Streamable HTTP on
+# `port` at path /mcp. mcp-gateway consumes it via:
+#   http://agentmemory.<ns>.svc.cluster.local:3114/mcp   (no auth)
+# The stdio server talks to the in-pod REST API via its default
+# AGENTMEMORY_URL=http://localhost:3111 (shared pod network namespace).
+mcpBridge:
+  enabled: true
+  port: 3114
+  # Pinned for reproducibility; npx fetches it at container start (needs
+  # registry access). Bake into the image later if cold-start matters.
+  supergatewayVersion: "3.4.3"
+  resources:
+    requests: {cpu: 25m, memory: 64Mi}
+    limits: {cpu: 500m, memory: 256Mi}
 
 # PVC for the /data directory (state store + stream store).
 persistence:
@@ -102,8 +143,21 @@ config:
   # the ingress viewer hostname (auto-included when ingress.enabled).
   corsExtraOrigins: []
 
+# No AGENTMEMORY_SECRET and no AGENTMEMORY_VIEWER_HOST -- intentional.
+# With the secret unset, agentmemory v0.11.2 serves the entire REST/MCP API
+# fully open (checkAuth returns open when the secret is falsy), which is what
+# mcp-gateway needs for zero-auth in-cluster consumption. The viewer binds
+# loopback inside the pod and is re-exposed by the socat sidecar (viewerProxy).
+# Do NOT set AGENTMEMORY_SECRET: it would auth-gate the MCP API as a side
+# effect. Do NOT set AGENTMEMORY_VIEWER_HOST: a non-loopback value makes the
+# process fatally exit without a secret.
+#
+# VIEWER_ALLOWED_HOSTS extends the viewer's Host-header allowlist (the viewer
+# 403s "forbidden host" otherwise). It is gate-free -- setting it does NOT
+# require the secret. Must contain every host:port the browser will use.
 env:
   TZ: "UTC"
+  VIEWER_ALLOWED_HOSTS: "localhost:3113,agentmemory.gnorplabs.cc:3113"
 
 # TODO: wire optional LLM/embedding provider keys (ANTHROPIC_API_KEY,
 # OPENAI_API_KEY, GEMINI_API_KEY, VOYAGE_API_KEY, etc.) via an

--- a/charts/agentmemory/values.yaml
+++ b/charts/agentmemory/values.yaml
@@ -115,8 +115,8 @@ mcpBridge:
   # registry access). Bake into the image later if cold-start matters.
   supergatewayVersion: "3.4.3"
   resources:
-    requests: {cpu: 25m, memory: 64Mi}
-    limits: {cpu: 500m, memory: 256Mi}
+    requests: {cpu: 25m, memory: 256Mi}
+    limits: {cpu: 500m, memory: 1Gi}
 
 # PVC for the /data directory (state store + stream store).
 persistence:

--- a/charts/agentmemory/values.yaml
+++ b/charts/agentmemory/values.yaml
@@ -60,8 +60,13 @@ service:
 # URL. This will not survive being accessed through this hostname-based
 # ingress and gracefully degrades to the viewer's existing 10s HTTP-polling
 # fallback -- a known upstream limitation, not something this chart solves.
+# Viewer ingress disabled: agentmemory v0.9.28 requires AGENTMEMORY_SECRET when
+# binding the viewer to non-loopback. Since this deployment is intentionally
+# unauthenticated, the viewer stays on loopback and is accessed via:
+#   kubectl port-forward -n mcp-gateway svc/agentmemory 3113:3113
+# then open http://localhost:3113 in your browser.
 ingress:
-  enabled: true
+  enabled: false
   className: "traefik"
   annotations: {}
   host: "agentmemory.gnorplabs.cc"

--- a/charts/agentmemory/values.yaml
+++ b/charts/agentmemory/values.yaml
@@ -28,14 +28,13 @@ serviceAccount:
 podAnnotations: {}
 podLabels: {}
 
-# fsGroup 1000 matches the image's `USER node` (uid 1000, node:22-slim base)
-# so the /data PersistentVolume is writable without a chown init container.
-podSecurityContext:
-  fsGroup: 1000
+# The agentmemory image's own entrypoint (the `agentmemory` CLI) runs as
+# root and chowns /data to the `node` user before dropping privileges, so the
+# container must run as root (no forced runAsUser/runAsGroup/fsGroup). This
+# matches the mcp-gateway chart's empty security context.
+podSecurityContext: {}
 
-securityContext:
-  runAsUser: 1000
-  runAsGroup: 1000
+securityContext: {}
 
 service:
   type: ClusterIP
@@ -88,8 +87,12 @@ persistence:
 # broken `host: [IP_ADDRESS]` placeholder on the iii-http/iii-stream
 # workers -- unquoted in YAML this parses as a one-item array, not a valid
 # bind address. This chart mirrors agentmemory's own known-working
-# iii-config.docker.yaml (0.0.0.0 binds) instead.
+# iii-config.docker.yaml ([IP_ADDRESS] = all-interfaces bind) instead.
 config:
+  # Bind host for the iii-http / iii-stream workers. Leave empty to let
+  # iii-engine default to all-interfaces (so the pod IP is reachable by
+  # kubelet probes). Set to a specific address only if needed.
+  bindHost: ""
   # Extra CORS allowed_origins appended alongside the localhost defaults and
   # the ingress viewer hostname (auto-included when ingress.enabled).
   corsExtraOrigins: []
@@ -116,8 +119,8 @@ resources: {}
   #   cpu: 100m
   #   memory: 256Mi
 
-# Generous startup probe to cover the ~9-10s cold start (npm package init +
-# iii engine boot) without triggering restart loops.
+# Probes omit `host` so kubelet dials the pod IP directly. The chart's iii
+# config binds [IP_ADDRESS] (all interfaces), so the pod IP is reachable.
 startupProbe:
   httpGet:
     path: /agentmemory/livez
@@ -137,7 +140,7 @@ livenessProbe:
 
 readinessProbe:
   httpGet:
-    path: /agentmemory/health
+    path: /agentmemory/livez
     port: http
   periodSeconds: 10
   timeoutSeconds: 5

--- a/charts/agentmemory/values.yaml
+++ b/charts/agentmemory/values.yaml
@@ -1,0 +1,150 @@
+# Default values for agentmemory.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/gnorplabs/agentmemory
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "latest"
+
+# Namespace agentmemory is deployed into (shared with mcp-gateway, its
+# primary in-cluster consumer). This field is informational only; the actual
+# namespace is set at the helm/helmfile release level.
+namespace: "mcp-gateway"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  automount: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+# fsGroup 1000 matches the image's `USER node` (uid 1000, node:22-slim base)
+# so the /data PersistentVolume is writable without a chown init container.
+podSecurityContext:
+  fsGroup: 1000
+
+securityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+
+service:
+  type: ClusterIP
+  ports:
+    # REST API + MCP HTTP surface. Consumed in-cluster (e.g. by mcp-gateway)
+    # via the Service DNS name; intentionally not exposed via ingress.
+    http: 3111
+    # Internal iii-engine stream worker. Not exposed externally.
+    stream: 3112
+    # Real-time viewer UI. The only port exposed via ingress.
+    viewer: 3113
+    # iii-engine websocket (worker registration). Not exposed externally.
+    engine: 49134
+    # Prometheus-style metrics.
+    metrics: 9464
+
+# Only the viewer is exposed via ingress. The viewer's frontend proxies REST
+# calls to the API server-side (browser never calls port 3111 directly), so
+# the API needs no public hostname of its own.
+#
+# Note: live-update WebSocket connections (port 3112) are made directly from
+# the browser using client-side port arithmetic that assumes a raw `:port`
+# URL. This will not survive being accessed through this hostname-based
+# ingress and gracefully degrades to the viewer's existing 10s HTTP-polling
+# fallback -- a known upstream limitation, not something this chart solves.
+ingress:
+  enabled: true
+  className: "traefik"
+  annotations: {}
+  host: "agentmemory.gnorplabs.cc"
+  path: /
+  pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+# PVC for the /data directory (state store + stream store).
+persistence:
+  # Optionally specify claimName to manually override the PVC to be used.
+  # If claimName is specified, storageClass and size are ignored.
+  # claimName: ""
+  storageClass: "freenas-iscsi-csi"
+  size: 5Gi
+  accessMode: ReadWriteOnce
+
+# iii-engine config, rendered into a ConfigMap and mounted over
+# /app/config.yaml. This intentionally replaces the config baked into the
+# image (docker/agentmemory/iii-config.yaml in GnorpLabs), which has a
+# broken `host: [IP_ADDRESS]` placeholder on the iii-http/iii-stream
+# workers -- unquoted in YAML this parses as a one-item array, not a valid
+# bind address. This chart mirrors agentmemory's own known-working
+# iii-config.docker.yaml (0.0.0.0 binds) instead.
+config:
+  # Extra CORS allowed_origins appended alongside the localhost defaults and
+  # the ingress viewer hostname (auto-included when ingress.enabled).
+  corsExtraOrigins: []
+
+env:
+  TZ: "UTC"
+
+# TODO: wire optional LLM/embedding provider keys (ANTHROPIC_API_KEY,
+# OPENAI_API_KEY, GEMINI_API_KEY, VOYAGE_API_KEY, etc.) via an
+# existingSecret reference once needed. Intentionally left out of v1 --
+# agentmemory runs in BM25-only / zero-external-call mode without them.
+# providerSecrets:
+#   existingSecret: ""
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 500m
+  #   memory: 512Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 256Mi
+
+# Generous startup probe to cover the ~9-10s cold start (npm package init +
+# iii engine boot) without triggering restart loops.
+startupProbe:
+  httpGet:
+    path: /agentmemory/livez
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 3
+  timeoutSeconds: 3
+  failureThreshold: 10
+
+livenessProbe:
+  httpGet:
+    path: /agentmemory/livez
+    port: http
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /agentmemory/health
+    port: http
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/mcp-gateway/values.yaml
+++ b/charts/mcp-gateway/values.yaml
@@ -107,6 +107,7 @@ gateway:
   auth:
     enabled: true
     bearerToken: "auto"
+
   metaMcp:
     enabled: true
     cacheTools: true


### PR DESCRIPTION
## Description

This PR adds a comprehensive Helm chart for AgentMemory, a persistent memory server for AI coding agents built on the `iii` engine. The chart deploys AgentMemory with full MCP (Model Context Protocol) integration via a sidecar gateway.

## Features

### Core Deployment
- **Persistent memory server** using the `iii` engine
- **REST API** (port 3111) for programmatic access
- **MCP server** integration for standardized agent memory
- **Real-time viewer UI** (port 3113) for human monitoring
- **StatefulSet-based deployment** with persistent storage

### MCP Integration
- **mcp-gateway sidecar** (port 3114) for standardized MCP protocol
- Uses supergateway v3.4.3 for MCP bridge functionality
- Optimized resource allocation (256Mi-1Gi memory)
- Automatic connection to AgentMemory REST API

### Network Exposure
- **HTTP Ingress** (disabled by default) for REST/MCP API
- **TCP Ingress** via Traefik for unauthenticated LAN viewer access
- In-cluster Service for mcp-gateway consumption
- Separate viewer service for UI access

### Storage & Configuration
- **5Gi PVC** (freenas-iscsi-csi) for persistent /data directory
- **ConfigMap** for environment configuration
- **ServiceAccount** for RBAC
- Configurable resource limits and requests

## Chart Details

- **Name**: agentmemory
- **Version**: 0.1.0
- **App Version**: latest
- **Type**: application
- **Image**: ghcr.io/gnorplabs/agentmemory:latest

## Changes Included

### Initial Implementation
- Add complete Helm chart structure (Chart.yaml, values.yaml, README.md)
- Add Kubernetes templates (Deployment, Service, Ingress, PVC, ConfigMap, ServiceAccount)
- Add comprehensive documentation with parameter tables

### Configuration Fixes
- Correct entrypoint and config integration
- Fix environment variables (AGENTMEMORY_VIEWER_HOST, VIEWER_ALLOWED_HOSTS)
- Disable HTTP ingress (unauthenticated service, LAN-only)
- Remove viewer host override for security

### MCP Bridge Enhancement
- Add Traefik TCP ingress for no-auth LAN viewer access
- Integrate mcp-gateway sidecar for MCP protocol support
- Optimize sidecar resources (256Mi-1Gi memory based on operational needs)

## Commits

1. `3841d7d` - feat(agentmemory): add agentmemory Helm chart
2. `db0dfe3` - fix(agentmemory): correct entrypoint/config integration and probe
3. `ffc814a` - fix(agentmemory): set AGENTMEMORY_VIEWER_HOST and VIEWER_ALLOWED_HOSTS
4. `b759b0e` - fix(agentmemory): disable ingress and viewer host override -- unauthenticated
5. `e5b2c1f` - feat(agentmemory): no-auth LAN viewer via Traefik TCP + MCP bridge sidecar
6. `5b3bebe` - fix(agentmemory): increase MCP bridge sidecar memory limits

## Deployment Notes

**Prerequisites:**
- Kubernetes 1.19+
- Helm 3.0+
- PersistentVolume provisioner (freenas-iscsi-csi configured)
- Traefik ingress controller (for TCP ingress)

**Install:**
```bash
helm install agentmemory ./charts/agentmemory -n mcp-gateway --create-namespace
```

**Primary consumer:** mcp-gateway (in-cluster REST/MCP API on port 3111)

**Viewer access:** LAN only via TCP ingress (port 3113, unauthenticated)

## Files Changed

```
charts/agentmemory/.helmignore
charts/agentmemory/Chart.yaml
charts/agentmemory/README.md
charts/agentmemory/templates/_helpers.tpl
charts/agentmemory/templates/configmap.yaml
charts/agentmemory/templates/deployment.yaml
charts/agentmemory/templates/ingress-tcp.yaml
charts/agentmemory/templates/ingress.yaml
charts/agentmemory/templates/pvc.yaml
charts/agentmemory/templates/service.yaml
charts/agentmemory/templates/serviceaccount.yaml
charts/agentmemory/values.yaml
```

**Total: 12 files, ~800 lines**