### PR TITLE
fix(omniroute): make securityContext configurable, default fsGroup 1000

### DIFF
--- a/charts/omniroute/templates/statefulset.yaml
+++ b/charts/omniroute/templates/statefulset.yaml
@@ -32,6 +32,11 @@ spec:
       labels:
         {{- include "omniroute.labels" . | nindent 8 }}
     spec:
+      # OmniRoute runs as UID 1000 (node). fsGroup ensures the mounted PVC is
+      # chowned to this group on attach, allowing the process to write its
+      # SQLite database and logs to /app/data.
+      securityContext:
+        fsGroup: 1000
       containers:
         # Core OmniRoute container
         - name: omniroute

--- a/charts/omniroute/templates/statefulset.yaml
+++ b/charts/omniroute/templates/statefulset.yaml
@@ -32,16 +32,15 @@ spec:
       labels:
         {{- include "omniroute.labels" . | nindent 8 }}
     spec:
-      # OmniRoute runs as UID 1000 (node). fsGroup ensures the mounted PVC is
-      # chowned to this group on attach, allowing the process to write its
-      # SQLite database and logs to /app/data.
       securityContext:
-        fsGroup: 1000
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         # Core OmniRoute container
         - name: omniroute
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           ports:
             {{- if .Values.service.ports.dashboard.enabled }}
             - name: dashboard

--- a/charts/omniroute/values.yaml
+++ b/charts/omniroute/values.yaml
@@ -91,6 +91,15 @@ ingress:
           pathType: Prefix
   tls: []
 
+# ── Security Context ──────────────────────────────────────────────────────────
+# OmniRoute runs as the 'node' user (UID 1000). fsGroup ensures the mounted
+# PVC is chowned to this group on attach so the process can write its SQLite
+# database and logs to /app/data.
+podSecurityContext:
+  fsGroup: 1000
+
+securityContext: {}
+
 # ── Node Scheduling (Optional) ─────────────────────────────────────────────
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
OmniRoute runs as the `node` user (UID 1000). Without `fsGroup: 1000` on the pod securityContext, Kubernetes mounts the PVC owned by root and OmniRoute can't write to `/app/data`. It falls back to in-memory sql.js and loses all data (API keys, settings, providers) on every restart.

## Changes

- **`templates/statefulset.yaml`** — wire `podSecurityContext` and `securityContext` from values into the pod/container spec
- **`values.yaml`** — add `podSecurityContext: fsGroup: 1000` as the default (correct for OmniRoute's node user); overridable per-deployment via the helmfile values file