### PR TITLE
chore(omniroute): bump chart to 0.2.0

### DIFF
--- a/charts/omniroute/Chart.yaml
+++ b/charts/omniroute/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: omniroute
 description: A Helm chart for OmniRoute - Unified AI proxy for 271 LLM providers
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "latest"


### PR DESCRIPTION
Bumps chart version so chart-releaser publishes the securityContext changes from #27.