### PR TITLE
feat(omniroute): auto-derive public URL from ingress for OAuth redirects

### DIFF
--- a/charts/omniroute/Chart.yaml
+++ b/charts/omniroute/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: omniroute
 description: A Helm chart for OmniRoute - Unified AI proxy for 271 LLM providers
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: "latest"

--- a/charts/omniroute/Chart.yaml
+++ b/charts/omniroute/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: omniroute
 description: A Helm chart for OmniRoute - Unified AI proxy for 271 LLM providers
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "latest"

--- a/charts/omniroute/templates/configmap.yaml
+++ b/charts/omniroute/templates/configmap.yaml
@@ -7,6 +7,21 @@ metadata:
 data:
   NODE_ENV: "production"
   PORT: "{{ .Values.service.ports.dashboard.port }}"
+  {{- /* Derive the public base URL for OAuth redirect_uri computation.
+       Explicit publicUrl always wins; otherwise infer from ingress host + TLS. */}}
+  {{- if .Values.publicUrl }}
+  NEXT_PUBLIC_BASE_URL: {{ .Values.publicUrl | quote }}
+  OMNIROUTE_PUBLIC_BASE_URL: {{ .Values.publicUrl | quote }}
+  {{- else if and .Values.ingress.enabled .Values.ingress.hosts }}
+  {{- $host := (index .Values.ingress.hosts 0).host }}
+  {{- if .Values.ingress.tls }}
+  NEXT_PUBLIC_BASE_URL: {{ printf "https://%s" $host | quote }}
+  OMNIROUTE_PUBLIC_BASE_URL: {{ printf "https://%s" $host | quote }}
+  {{- else }}
+  NEXT_PUBLIC_BASE_URL: {{ printf "http://%s" $host | quote }}
+  OMNIROUTE_PUBLIC_BASE_URL: {{ printf "http://%s" $host | quote }}
+  {{- end }}
+  {{- end }}
 {{- if .Values.redis.enabled }}
   REDIS_URL: "redis://localhost:6379"
 {{- end }}

--- a/charts/omniroute/values.yaml
+++ b/charts/omniroute/values.yaml
@@ -67,6 +67,39 @@ resources:
     cpu: 250m
     memory: 1024Mi
 
+# ── Public URL ────────────────────────────────────────────────────────────────
+# Sets NEXT_PUBLIC_BASE_URL and OMNIROUTE_PUBLIC_BASE_URL, which OmniRoute uses
+# to compute OAuth redirect_uri values. When left empty, the chart auto-derives
+# the URL from the first ingress host (https:// if TLS is configured, http://
+# otherwise). Set explicitly if your public URL differs from the ingress host.
+publicUrl: ""
+
+# ── OAuth Provider Credentials ────────────────────────────────────────────────
+# Google-based providers (Gemini, Antigravity) ship bundled OAuth credentials
+# that only accept loopback redirects (127.0.0.1). For remote/k8s deployments
+# you have two options:
+#
+# Option 1 — Use envFromSecrets to inject custom provider OAuth credentials.
+# Register your own OAuth app with your public URL as the redirect URI, store
+# the credentials as a k8s secret, and reference them here. Example:
+#
+#   kubectl create secret generic omniroute-oauth \
+#     -n mcp-gateway \
+#     --from-literal=GEMINI_OAUTH_CLIENT_ID=<id> \
+#     --from-literal=GEMINI_OAUTH_CLIENT_SECRET=<secret> \
+#     --from-literal=ANTIGRAVITY_OAUTH_CLIENT_ID=<id> \
+#     --from-literal=ANTIGRAVITY_OAUTH_CLIENT_SECRET=<secret>
+#
+#   envFromSecrets:
+#     - name: GEMINI_OAUTH_CLIENT_ID
+#       secretName: omniroute-oauth
+#       secretKey: GEMINI_OAUTH_CLIENT_ID
+#     ... etc
+#
+# Option 2 — Use kubectl port-forward to do the OAuth flow locally:
+#   kubectl port-forward -n mcp-gateway statefulset/omniroute 20128:20128
+#   Then open http://localhost:20128 and connect providers normally.
+
 # ── Additional Environment Variables ────────────────────────────────────────
 env: {}  # Example: { OMNI_MAX_CONCURRENT_CONNECTIONS: "50" }
 


### PR DESCRIPTION
OmniRoute's bundled Google OAuth credentials only accept loopback redirects. When deployed in k8s with a public ingress, OAuth flows fail because `NEXT_PUBLIC_BASE_URL` defaults to `http://localhost:20128`.

## Changes

- **`templates/configmap.yaml`** — auto-sets `NEXT_PUBLIC_BASE_URL` and `OMNIROUTE_PUBLIC_BASE_URL` from the first ingress host (`https://` when TLS is configured, `http://` otherwise). Explicit `publicUrl` value always takes precedence.
- **`values.yaml`** — adds `publicUrl` field and documents the two options for remote OAuth: custom provider credentials via `envFromSecrets`, or `kubectl port-forward` for one-off setup.
- **`Chart.yaml`** — bumped to 0.3.0